### PR TITLE
Change active directory variable names

### DIFF
--- a/deployments/gcp/dc-only/main.tf
+++ b/deployments/gcp/dc-only/main.tf
@@ -26,14 +26,14 @@ module "dc" {
 
   prefix = var.prefix
 
-  gcp_service_account      = var.gcp_service_account
-  kms_cryptokey_id         = var.kms_cryptokey_id
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  safe_mode_admin_password = var.safe_mode_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
-  domain_users_list        = var.domain_users_list
+  gcp_service_account         = var.gcp_service_account
+  kms_cryptokey_id            = var.kms_cryptokey_id
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  safe_mode_admin_password    = var.safe_mode_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
+  domain_users_list           = var.domain_users_list
 
   bucket_name  = google_storage_bucket.scripts.name
   gcp_zone     = var.gcp_zone

--- a/deployments/gcp/dc-only/terraform.tfvars.sample
+++ b/deployments/gcp/dc-only/terraform.tfvars.sample
@@ -40,6 +40,6 @@ kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring
 #    3. unicode characters
 # See: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
 
-dc_admin_password        = "SecuRe_pwd1"
-safe_mode_admin_password = "SecuRe_pwd2"
-service_account_password = "SecuRe_pwd3"
+dc_admin_password           = "SecuRe_pwd1"
+safe_mode_admin_password    = "SecuRe_pwd2"
+ad_service_account_password = "SecuRe_pwd3"

--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -87,12 +87,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account name to be created"
   default     = "cam_admin"
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -26,14 +26,14 @@ module "dc" {
 
   prefix = var.prefix
 
-  gcp_service_account      = var.gcp_service_account
-  kms_cryptokey_id         = var.kms_cryptokey_id
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  safe_mode_admin_password = var.safe_mode_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
-  domain_users_list        = var.domain_users_list
+  gcp_service_account         = var.gcp_service_account
+  kms_cryptokey_id            = var.kms_cryptokey_id
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  safe_mode_admin_password    = var.safe_mode_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
+  domain_users_list           = var.domain_users_list
 
   bucket_name  = google_storage_bucket.scripts.name
   gcp_zone     = var.gcp_zone
@@ -63,10 +63,10 @@ module "cac-igm" {
   pcoip_registration_code = var.pcoip_registration_code
   cac_token               = var.cac_token
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   #gcp_region   = "${var.gcp_region}"
   bucket_name   = google_storage_bucket.scripts.name
@@ -151,14 +151,14 @@ module "win-gfx" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -186,14 +186,14 @@ module "win-std" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -219,14 +219,14 @@ module "centos-gfx" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -257,14 +257,14 @@ module "centos-std" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -84,8 +84,8 @@ kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring
 #    3. unicode characters
 # See: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
 
-dc_admin_password        = "SecuRe_pwd1"
-safe_mode_admin_password = "SecuRe_pwd2"
-service_account_password = "SecuRe_pwd3"
-pcoip_registration_code  = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                = "token from Cloud Access Manager for the connector"
+dc_admin_password           = "SecuRe_pwd1"
+safe_mode_admin_password    = "SecuRe_pwd2"
+ad_service_account_password = "SecuRe_pwd3"
+pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
+cac_token                   = "token from Cloud Access Manager for the connector"

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -87,12 +87,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account name to be created"
   default     = "cam_admin"
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -26,14 +26,14 @@ module "dc" {
 
   prefix = var.prefix
 
-  gcp_service_account      = var.gcp_service_account
-  kms_cryptokey_id         = var.kms_cryptokey_id
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  safe_mode_admin_password = var.safe_mode_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
-  domain_users_list        = var.domain_users_list
+  gcp_service_account         = var.gcp_service_account
+  kms_cryptokey_id            = var.kms_cryptokey_id
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  safe_mode_admin_password    = var.safe_mode_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
+  domain_users_list           = var.domain_users_list
 
   bucket_name  = google_storage_bucket.scripts.name
   gcp_zone     = var.gcp_zone
@@ -63,10 +63,10 @@ module "cac" {
   pcoip_registration_code = var.pcoip_registration_code
   cac_token               = var.cac_token
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name  = google_storage_bucket.scripts.name
   gcp_zone     = var.gcp_zone
@@ -98,14 +98,14 @@ module "win-gfx" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -133,14 +133,14 @@ module "win-std" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -166,14 +166,14 @@ module "centos-gfx" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone
@@ -204,14 +204,14 @@ module "centos-std" {
   prefix = var.prefix
 
   gcp_service_account = var.gcp_service_account
-  kms_cryptokey_id = var.kms_cryptokey_id
+  kms_cryptokey_id    = var.kms_cryptokey_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name      = google_storage_bucket.scripts.name
   gcp_zone         = var.gcp_zone

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -74,9 +74,9 @@ kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring
 #    3. unicode characters
 # See: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
 
-dc_admin_password        = "SecuRe_pwd1"
-safe_mode_admin_password = "SecuRe_pwd2"
-service_account_password = "SecuRe_pwd3"
-pcoip_registration_code  = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                = "token from Cloud Access Manager for the connector"
+dc_admin_password           = "SecuRe_pwd1"
+safe_mode_admin_password    = "SecuRe_pwd2"
+ad_service_account_password = "SecuRe_pwd3"
+pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
+cac_token                   = "token from Cloud Access Manager for the connector"
 

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -133,12 +133,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account name to be created"
   default     = "cam_admin"
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/modules/gcp/cac-igm/cac-startup.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-startup.sh.tmpl
@@ -23,7 +23,7 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
         CAC_TOKEN=${cac_token}
 
     else
@@ -40,9 +40,9 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${service_account_password}\" }")
+        data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
         data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
@@ -50,7 +50,7 @@ get_credentials() {
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
         exit 1
     fi
 }
@@ -110,13 +110,13 @@ echo '### Ensure AD account is available ###'
 TIMEOUT=1200
 until ldapwhoami \
     -H ldap://${domain_controller_ip} \
-    -D ${service_account_username}@${domain_name} \
-    -w $SERVICE_ACCOUNT_PASSWORD \
+    -D ${ad_service_account_username}@${domain_name} \
+    -w $AD_SERVICE_ACCOUNT_PASSWORD \
     -o nettimeout=1; do
     if [ $TIMEOUT -le 0 ]; then
         break
     else
-        echo "Waiting for AD account ${service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
+        echo "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
     fi
     TIMEOUT=$((TIMEOUT-10))
     sleep 10
@@ -131,8 +131,8 @@ if [ -z "${ssl_key}" ]; then
         -t $CAC_TOKEN \
         --accept-policies \
         --insecure \
-        --sa-user ${service_account_username} \
-        --sa-password "$SERVICE_ACCOUNT_PASSWORD" \
+        --sa-user ${ad_service_account_username} \
+        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
         --domain ${domain_name} \
         --domain-group "${domain_group}" \
         --reg-code $PCOIP_REGISTRATION_CODE \
@@ -147,8 +147,8 @@ else
         --accept-policies \
         --ssl-key $INSTALL_DIR/${ssl_key} \
         --ssl-cert $INSTALL_DIR/${ssl_cert} \
-        --sa-user ${service_account_username} \
-        --sa-password "$SERVICE_ACCOUNT_PASSWORD" \
+        --sa-user ${ad_service_account_username} \
+        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
         --domain ${domain_name} \
         --domain-group "${domain_group}" \
         --reg-code $PCOIP_REGISTRATION_CODE \

--- a/modules/gcp/cac-igm/main.tf
+++ b/modules/gcp/cac-igm/main.tf
@@ -43,17 +43,17 @@ resource "google_storage_bucket_object" "cac-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      cam_url                  = var.cam_url,
-      cac_installer_url        = var.cac_installer_url,
-      cac_token                = var.cac_token,
-      pcoip_registration_code  = var.pcoip_registration_code,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      cam_url                     = var.cam_url,
+      cac_installer_url           = var.cac_installer_url,
+      cac_token                   = var.cac_token,
+      pcoip_registration_code     = var.pcoip_registration_code,
 
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      domain_group             = var.domain_group,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      domain_group                = var.domain_group,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
 
       bucket_name = var.bucket_name,
       ssl_key     = "",

--- a/modules/gcp/cac-igm/vars.tf
+++ b/modules/gcp/cac-igm/vars.tf
@@ -45,12 +45,12 @@ variable "domain_group" {
   default     = "Domain Admins"
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/cac/cac-startup.sh.tmpl
+++ b/modules/gcp/cac/cac-startup.sh.tmpl
@@ -23,7 +23,7 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
         CAC_TOKEN=${cac_token}
 
     else
@@ -40,9 +40,9 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${service_account_password}\" }")
+        data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
         data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
@@ -50,7 +50,7 @@ get_credentials() {
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
         exit 1
     fi
 }
@@ -110,13 +110,13 @@ echo '### Ensure AD account is available ###'
 TIMEOUT=1200
 until ldapwhoami \
     -H ldap://${domain_controller_ip} \
-    -D ${service_account_username}@${domain_name} \
-    -w $SERVICE_ACCOUNT_PASSWORD \
+    -D ${ad_service_account_username}@${domain_name} \
+    -w $AD_SERVICE_ACCOUNT_PASSWORD \
     -o nettimeout=1; do
     if [ $TIMEOUT -le 0 ]; then
         break
     else
-        echo "Waiting for AD account ${service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
+        echo "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
     fi
     TIMEOUT=$((TIMEOUT-10))
     sleep 10
@@ -131,8 +131,8 @@ if [ -z "${ssl_key}" ]; then
         -t $CAC_TOKEN \
         --accept-policies \
         --insecure \
-        --sa-user ${service_account_username} \
-        --sa-password "$SERVICE_ACCOUNT_PASSWORD" \
+        --sa-user ${ad_service_account_username} \
+        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
         --domain ${domain_name} \
         --domain-group "${domain_group}" \
         --reg-code $PCOIP_REGISTRATION_CODE \
@@ -147,8 +147,8 @@ else
         --accept-policies \
         --ssl-key $INSTALL_DIR/${ssl_key} \
         --ssl-cert $INSTALL_DIR/${ssl_cert} \
-        --sa-user ${service_account_username} \
-        --sa-password "$SERVICE_ACCOUNT_PASSWORD" \
+        --sa-user ${ad_service_account_username} \
+        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
         --domain ${domain_name} \
         --domain-group "${domain_group}" \
         --reg-code $PCOIP_REGISTRATION_CODE \

--- a/modules/gcp/cac/main.tf
+++ b/modules/gcp/cac/main.tf
@@ -41,17 +41,17 @@ resource "google_storage_bucket_object" "startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      cam_url                  = var.cam_url,
-      cac_installer_url        = var.cac_installer_url,
-      cac_token                = var.cac_token,
-      pcoip_registration_code  = var.pcoip_registration_code,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      cam_url                     = var.cam_url,
+      cac_installer_url           = var.cac_installer_url,
+      cac_token                   = var.cac_token,
+      pcoip_registration_code     = var.pcoip_registration_code,
 
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      domain_group             = var.domain_group,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      domain_group                = var.domain_group,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
 
       bucket_name = var.bucket_name,
       ssl_key     = local.ssl_key_filename,

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -45,12 +45,12 @@ variable "domain_group" {
   default     = "Domain Admins"
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -21,7 +21,7 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
 
     else
         log "Using encryption key ${kms_cryptokey_id}"
@@ -34,13 +34,13 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${service_account_password}\" }")
+        data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" ]]; then
         exit 1
     fi
 }
@@ -178,17 +178,17 @@ join_domain()
     if [[ ! -f "$dns_record_file" ]]
     then
         log "--> DOMAIN NAME: ${domain_name}"
-        log "--> USERNAME: ${service_account_username}"
+        log "--> USERNAME: ${ad_service_account_username}"
         log "--> DOMAIN CONTROLLER: ${domain_controller_ip}"
 
         VM_NAME=$(hostname)
 
         # Wait for AD service account to be set up
         yum -y install openldap-clients
-        log "--> Wait for AD account ${service_account_username}@${domain_name} to be available"
-        until ldapwhoami -H ldap://${domain_controller_ip} -D ${service_account_username}@${domain_name} -w $SERVICE_ACCOUNT_PASSWORD -o nettimeout=1 > /dev/null 2>&1
+        log "--> Wait for AD account ${ad_service_account_username}@${domain_name} to be available"
+        until ldapwhoami -H ldap://${domain_controller_ip} -D ${ad_service_account_username}@${domain_name} -w $AD_SERVICE_ACCOUNT_PASSWORD -o nettimeout=1 > /dev/null 2>&1
         do
-            log "${service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
+            log "${ad_service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
             sleep 10
         done
 
@@ -213,9 +213,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]
@@ -236,7 +236,7 @@ join_domain()
         log "--> Registering with DNS"
         DOMAIN_UPPER=$(echo "${domain_name}" | tr '[:lower:]' '[:upper:]')
         IP_ADDRESS=$(hostname -I | grep -Eo '10.([0-9]*\.){2}[0-9]*')
-        echo "$SERVICE_ACCOUNT_PASSWORD" | kinit "${service_account_username}"@"$DOMAIN_UPPER"
+        echo "$AD_SERVICE_ACCOUNT_PASSWORD" | kinit "${ad_service_account_username}"@"$DOMAIN_UPPER"
         touch "$dns_record_file"
         echo "server ${domain_controller_ip}" > "$dns_record_file"
         echo "update add $VM_NAME.${domain_name} 600 a $IP_ADDRESS" >> "$dns_record_file"

--- a/modules/gcp/centos-gfx/main.tf
+++ b/modules/gcp/centos-gfx/main.tf
@@ -24,13 +24,13 @@ resource "google_storage_bucket_object" "centos-gfx-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      pcoip_registration_code  = var.pcoip_registration_code,
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
-      nvidia_driver_url        = var.nvidia_driver_url,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
+      nvidia_driver_url           = var.nvidia_driver_url,
     }
   )
 }

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -35,12 +35,12 @@ variable "domain_controller_ip" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-startup.sh.tmpl
@@ -21,7 +21,7 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
 
     else
         log "Using encryption key ${kms_cryptokey_id}"
@@ -34,13 +34,13 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${service_account_password}\" }")
+        data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" ]]; then
         exit 1
     fi
 }
@@ -97,17 +97,17 @@ join_domain()
     if [[ ! -f "$dns_record_file" ]]
     then
         log "--> DOMAIN NAME: ${domain_name}"
-        log "--> USERNAME: ${service_account_username}"
+        log "--> USERNAME: ${ad_service_account_username}"
         log "--> DOMAIN CONTROLLER: ${domain_controller_ip}"
 
         VM_NAME=$(hostname)
 
         # Wait for AD service account to be set up
         yum -y install openldap-clients
-        log "--> Wait for AD account ${service_account_username}@${domain_name} to be available"
-        until ldapwhoami -H ldap://${domain_controller_ip} -D ${service_account_username}@${domain_name} -w "$SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
+        log "--> Wait for AD account ${ad_service_account_username}@${domain_name} to be available"
+        until ldapwhoami -H ldap://${domain_controller_ip} -D ${ad_service_account_username}@${domain_name} -w "$AD_SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
         do
-            log "${service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
+            log "${ad_service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
             sleep 10
         done
 
@@ -132,9 +132,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]
@@ -155,7 +155,7 @@ join_domain()
         log "--> Registering with DNS"
         DOMAIN_UPPER=$(echo "${domain_name}" | tr '[:lower:]' '[:upper:]')
         IP_ADDRESS=$(hostname -I | grep -Eo '10.([0-9]*\.){2}[0-9]*')
-        echo "$SERVICE_ACCOUNT_PASSWORD" | kinit "${service_account_username}"@"$DOMAIN_UPPER"
+        echo "$AD_SERVICE_ACCOUNT_PASSWORD" | kinit "${ad_service_account_username}"@"$DOMAIN_UPPER"
         touch "$dns_record_file"
         echo "server ${domain_controller_ip}" > "$dns_record_file"
         echo "update add $VM_NAME.${domain_name} 600 a $IP_ADDRESS" >> "$dns_record_file"

--- a/modules/gcp/centos-std/main.tf
+++ b/modules/gcp/centos-std/main.tf
@@ -24,12 +24,12 @@ resource "google_storage_bucket_object" "centos-std-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      pcoip_registration_code  = var.pcoip_registration_code,
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/gcp/centos-std/vars.tf
+++ b/modules/gcp/centos-std/vars.tf
@@ -35,12 +35,12 @@ variable "domain_controller_ip" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/dc/main.tf
+++ b/modules/gcp/dc/main.tf
@@ -48,8 +48,8 @@ data "template_file" "new-domain-admin-user-script" {
     kms_cryptokey_id = var.kms_cryptokey_id
     host_name        = local.host_name
     domain_name      = var.domain_name
-    account_name     = var.service_account_username
-    account_password = var.service_account_password
+    account_name     = var.ad_service_account_username
+    account_password = var.ad_service_account_password
   }
 }
 

--- a/modules/gcp/dc/vars.tf
+++ b/modules/gcp/dc/vars.tf
@@ -30,12 +30,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account to be created"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/modules/gcp/win-gfx/main.tf
+++ b/modules/gcp/win-gfx/main.tf
@@ -24,15 +24,15 @@ resource "google_storage_bucket_object" "win-gfx-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      pcoip_agent_location     = var.pcoip_agent_location,
-      pcoip_agent_filename     = var.pcoip_agent_filename,
-      pcoip_registration_code  = var.pcoip_registration_code,
-      nvidia_driver_url        = var.nvidia_driver_url,
-      domain_name              = var.domain_name,
-      admin_password           = var.admin_password,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      pcoip_agent_location        = var.pcoip_agent_location,
+      pcoip_agent_filename        = var.pcoip_agent_filename,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      nvidia_driver_url           = var.nvidia_driver_url,
+      domain_name                 = var.domain_name,
+      admin_password              = var.admin_password,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -30,12 +30,12 @@ variable "domain_name" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -17,7 +17,7 @@ $METADATA_AUTH_URI = "$($METADATA_BASE_URI)/service-accounts/default/token"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
-$DATA.Add("service_account_password", "${service_account_password}")
+$DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
@@ -56,10 +56,10 @@ function Decrypt-Credentials {
         $DATA."admin_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
 
         $resource = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-        $resource.Add("ciphertext", "${service_account_password}")
+        $resource.Add("ciphertext", "${ad_service_account_password}")
         $response = Invoke-RestMethod -Method "Post" -Headers $headers -Uri $DECRYPT_URI -Body $resource
         $credsB64 = $response."plaintext"
-        $DATA."service_account_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
+        $DATA."ad_service_account_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
     }
     catch {
         "Error decrypting credentials: $_"
@@ -203,8 +203,8 @@ function Join-Domain {
 
     "Computer not part of a domain. Joining ${domain_name}..."
 
-    $username = "${service_account_username}" + "@" + "${domain_name}"
-    $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
+    $username = "${ad_service_account_username}" + "@" + "${domain_name}"
+    $password = ConvertTo-SecureString $DATA."ad_service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
     # Looping in case Domain Controller is not yet available

--- a/modules/gcp/win-std/main.tf
+++ b/modules/gcp/win-std/main.tf
@@ -31,8 +31,8 @@ resource "google_storage_bucket_object" "win-std-startup-script" {
 
       domain_name              = var.domain_name,
       admin_password           = var.admin_password,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/gcp/win-std/vars.tf
+++ b/modules/gcp/win-std/vars.tf
@@ -30,12 +30,12 @@ variable "domain_name" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -16,7 +16,7 @@ $METADATA_AUTH_URI = "$($METADATA_BASE_URI)/service-accounts/default/token"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
-$DATA.Add("service_account_password", "${service_account_password}")
+$DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
@@ -55,10 +55,10 @@ function Decrypt-Credentials {
         $DATA."admin_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
 
         $resource = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
-        $resource.Add("ciphertext", "${service_account_password}")
+        $resource.Add("ciphertext", "${ad_service_account_password}")
         $response = Invoke-RestMethod -Method "Post" -Headers $headers -Uri $DECRYPT_URI -Body $resource
         $credsB64 = $response."plaintext"
-        $DATA."service_account_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
+        $DATA."ad_service_account_password" = [System.Text.Encoding]::ASCII.GetString([System.Convert]::FromBase64String($credsB64))
     }
     catch {
         "Error decrypting credentials: $_"
@@ -160,8 +160,8 @@ function Join-Domain {
 
     "Computer not part of a domain. Joining ${domain_name}..."
 
-    $username = "${service_account_username}" + "@" + "${domain_name}"
-    $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
+    $username = "${ad_service_account_username}" + "@" + "${domain_name}"
+    $password = ConvertTo-SecureString $DATA."ad_service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
     # Looping in case Domain Controller is not yet available

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -381,7 +381,7 @@ if __name__ == '__main__':
         'kms_cryptokey_id':               key_name,
         'dc_admin_password':              password,
         'safe_mode_admin_password':       password,
-        'service_account_password':       password,
+        'ad_service_account_password':    password,
         'cac_admin_ssh_pub_key_file':     SSH_KEY_PATH + '.pub',
         'win_gfx_instance_count':         cfg_data.get('gwin'),
         'win_std_instance_count':         cfg_data.get('swin'),


### PR DESCRIPTION
To avoid confusion between GCP service accounts and Active
Directory service accounts, the service_account_username and
service_account_password variables are updated to use ad_ in the names.

Signed-off-by: Edwin Pau <epau@teradici.com>