### PR TITLE
Fix CAM HTTP Request

### DIFF
--- a/quickstart/cam.py
+++ b/quickstart/cam.py
@@ -71,8 +71,8 @@ class CloudAccessManager:
             'deploymentId': deployment['deploymentId'],
             'projectId':    project_id,
             'zone':         zone,
-            'active':       'true',
-            'managed':      'true',
+            'active':       True,
+            'managed':      True,
         }
 
         resp = requests.post(


### PR DESCRIPTION
CAM API now enforces boolean for 'active' and 'managed' fields of the
machines api for adding existing machines.

Signed-off-by: Sherman Yin <syin@teradici.com>