### PR TITLE
Change hostnames of workstations

### DIFF
--- a/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -27,6 +27,7 @@ Content-Disposition: attachment; filename="userdata.txt"
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
+METADATA_IP="http://169.254.169.254"
 
 log() {
     local message="$1"
@@ -46,6 +47,17 @@ get_credentials() {
         log "Service Account Password = $SERVICE_ACCOUNT_PASSWORD"
         exit 1
     fi
+}
+
+# Update the hostname to match this instance's "Name" Tag
+update_hostname()
+{
+    TOKEN=`curl -X PUT "$METADATA_IP/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+    ID=`curl $METADATA_IP/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN"`
+    REGION=`curl $METADATA_IP/latest/dynamic/instance-identity/document/ -H "X-aws-ec2-metadata-token: $TOKEN" | jq -r .region`
+    NEW_HOSTNAME=`aws ec2 describe-tags --region $REGION --filters "Name=resource-id,Values=$ID" "Name=key,Values=Name" --output json | jq -r .Tags[0].Value`
+
+    sudo hostnamectl set-hostname $NEW_HOSTNAME.${domain_name}
 }
 
 exit_and_restart()
@@ -302,7 +314,9 @@ then
 
     yum -y update
 
-    yum install -y wget
+    yum install -y wget awscli jq
+
+    update_hostname
 
     # Install GNOME and set it as the desktop
     log "--> Install Linux GUI ..."

--- a/modules/aws/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/aws/centos-std/centos-std-startup.sh.tmpl
@@ -8,6 +8,7 @@
 exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
+METADATA_IP="http://169.254.169.254"
 
 log() {
     local message="$1"
@@ -27,6 +28,17 @@ get_credentials() {
         log "Service Account Password = $SERVICE_ACCOUNT_PASSWORD"
         exit 1
     fi
+}
+
+# Update the hostname to match this instance's "Name" Tag
+update_hostname()
+{
+    TOKEN=`curl -X PUT "$METADATA_IP/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 60"`
+    ID=`curl $METADATA_IP/latest/meta-data/instance-id -H "X-aws-ec2-metadata-token: $TOKEN"`
+    REGION=`curl $METADATA_IP/latest/dynamic/instance-identity/document/ -H "X-aws-ec2-metadata-token: $TOKEN" | jq -r .region`
+    NEW_HOSTNAME=`aws ec2 describe-tags --region $REGION --filters "Name=resource-id,Values=$ID" "Name=key,Values=Name" --output json | jq -r .Tags[0].Value`
+
+    sudo hostnamectl set-hostname $NEW_HOSTNAME.${domain_name}
 }
 
 exit_and_restart()
@@ -183,7 +195,9 @@ yum -y install epel-release
 
 yum -y update
 
-yum install -y wget
+yum install -y wget awscli jq
+
+update_hostname
 
 # Install GNOME and set it as the desktop
 log "--> Install Linux GUI ..."

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -111,6 +111,10 @@ function Join-Domain {
     $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
+    # Read "Name" tag for hostname
+    $instance_id = Get-EC2InstanceMetadata -Category "InstanceId"
+    $host_name = Get-EC2Tag -Filter @{name="resource-id";value=$instance_id} | Select -ExpandProperty "value"
+
     # Looping in case Domain Controller is not yet available
     $Interval = 10
     $Timeout = 1200
@@ -120,7 +124,7 @@ function Join-Domain {
         Try {
             $Retry = $false
             # Don't do -Restart here because there is no log showing the restart
-            Add-Computer -DomainName "${domain_name}" -Credential $cred -Verbose -Force -ErrorAction Stop
+            Add-Computer -DomainName "${domain_name}" -NewName "$host_name" -Credential $cred -Verbose -Force -ErrorAction Stop
         }
 
         # The same Error, System.InvalidOperationException, is thrown in these cases: 
@@ -150,21 +154,28 @@ function Join-Domain {
         exit 1
     }
 
-    # In some cases the DNS entry is missing after domain join, register with
-    # DNS explicitly to ensure DNS entry exist.
-    "Explicitly registering with DNS..."
-    do {
-        ipconfig /registerdns
-    } while (!$?)
-    "Successfully registered with DNS."
-
     "Successfully joined '${domain_name}'"
     $global:restart = $true
 }
 
 
 if (Test-Path $LOG_FILE) {
+    Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
+
     "$LOG_FILE exists. Assume this startup script has run already."
+
+    # TODO: Find out why DNS entry is not always added after domain join.
+    # Sometimes the DNS entry for this workstation is not added in the Domain
+    # Controller after joining the domain. Explicitly adding this machine to the DNS
+    # after a reboot. Doing this before a reboot would add a DNS entry with the old
+    # hostname.
+    "Registering with DNS..."
+    do {
+        Start-Sleep -Seconds 5
+        Register-DnsClient
+    } while (!$?)
+    "Successfully registered with DNS."
+
     exit 0
 }
 
@@ -202,3 +213,4 @@ if ($global:restart) {
 }
 
 </powershell>
+<persist>true</persist>

--- a/modules/aws/win-std/win-std-startup.ps1.tmpl
+++ b/modules/aws/win-std/win-std-startup.ps1.tmpl
@@ -111,6 +111,10 @@ function Join-Domain {
     $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
+    # Read "Name" tag for hostname
+    $instance_id = Get-EC2InstanceMetadata -Category "InstanceId"
+    $host_name = Get-EC2Tag -Filter @{name="resource-id";value=$instance_id} | Select -ExpandProperty "value"
+
     # Looping in case Domain Controller is not yet available
     $Interval = 10
     $Timeout = 1200
@@ -120,7 +124,7 @@ function Join-Domain {
         Try {
             $Retry = $false
             # Don't do -Restart here because there is no log showing the restart
-            Add-Computer -DomainName "${domain_name}" -Credential $cred -Verbose -Force -ErrorAction Stop
+            Add-Computer -DomainName "${domain_name}" -NewName "$host_name" -Credential $cred -Verbose -Force -ErrorAction Stop
         }
 
         # The same Error, System.InvalidOperationException, is thrown in these cases: 
@@ -150,21 +154,27 @@ function Join-Domain {
         exit 1
     }
 
-    # In some cases the DNS entry is missing after domain join, register with
-    # DNS explicitly to ensure DNS entry exist.
-    "Explicitly registering with DNS..."
-    do {
-        ipconfig /registerdns
-    } while (!$?)
-    "Successfully registered with DNS."
-
     "Successfully joined '${domain_name}'"
     $global:restart = $true
 }
 
-
 if (Test-Path $LOG_FILE) {
+    Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
+
     "$LOG_FILE exists. Assume this startup script has run already."
+
+    # TODO: Find out why DNS entry is not always added after domain join.
+    # Sometimes the DNS entry for this workstation is not added in the Domain
+    # Controller after joining the domain. Explicitly adding this machine to the DNS
+    # after a reboot. Doing this before a reboot would add a DNS entry with the old
+    # hostname.
+    "Registering with DNS..."
+    do {
+        Start-Sleep -Seconds 5
+        Register-DnsClient
+    } while (!$?)
+    "Successfully registered with DNS."
+
     exit 0
 }
 
@@ -202,3 +212,4 @@ if ($global:restart) {
 }
 
 </powershell>
+<persist>true</persist>


### PR DESCRIPTION
Instead of using AWS-given hostnames, create ones which indicates the
type of workstation it is like in GCP.

Signed-off-by: Sherman Yin <syin@teradici.com>