### PR TITLE
Use CAM service account instead of CAC token (single)

### DIFF
--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -60,8 +60,8 @@ module "cac" {
   gcp_service_account     = var.gcp_service_account
   kms_cryptokey_id        = var.kms_cryptokey_id
   cam_url                 = var.cam_url
+  cam_credentials_file    = var.cam_credentials_file
   pcoip_registration_code = var.pcoip_registration_code
-  cac_token               = var.cac_token
 
   domain_name                 = var.domain_name
   domain_controller_ip        = module.dc.internal-ip

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -1,5 +1,5 @@
 # Commented out lines represents defaults that can be changed
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west1"
@@ -78,5 +78,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
-
+cam_credentials_file        = "/path/to/cam_cred.json"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -154,11 +154,6 @@ variable "ws_subnet_cidr" {
   default     = "10.0.2.0/24"
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
-  type        = string
-}
-
 variable "pcoip_registration_code" {
   description = "PCoIP Registration code"
   type        = string
@@ -167,6 +162,11 @@ variable "pcoip_registration_code" {
 variable "cam_url" {
   description = "cam server url."
   default     = "https://cam.teradici.com"
+}
+
+variable "cam_credentials_file" {
+  description = "Location of CAM JSON credentials file"
+  type        = string
 }
 
 variable "enable_workstation_public_ip" {

--- a/modules/gcp/cac/cac-startup.sh.tmpl
+++ b/modules/gcp/cac/cac-startup.sh.tmpl
@@ -18,13 +18,32 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$INSTALL_LOG"
 }
 
+get_cac_token() {
+    echo '### Retrieve connector token before CAC install ###'
+    log "Retrieving connector token..."
+
+    # Download and install python3
+    apt-get -qq update
+    apt install -y python3
+
+    # Download the CAM python script from the bucket and run it to create a cac token
+    gsutil cp gs://${bucket_name}/${cam_script_name} $INSTALL_DIR
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`python3 ${cam_script_name}`
+}
+
 get_credentials() {
+    # Download the CAM credentials JSON file from the bucket
+    gsutil cp gs://${bucket_name}/${cam_credentials_name} $INSTALL_DIR
+
     if [[ -z "${kms_cryptokey_id}" ]]; then
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
-        CAC_TOKEN=${cac_token}
+        
+        get_cac_token
 
     else
         log "Using encryption key ${kms_cryptokey_id}"
@@ -44,13 +63,19 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        CAC_TOKEN=$(echo "$b64_data" | base64 --decode)
+        # Gets decrypted CAM service account credentials and outputs to plaintext json file
+        cam_cred_encrypted=$(cat ${cam_credentials_name})
+        data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")     
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")   
+        CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
+        echo $CAM_CREDENTIALS | tee ${cam_credentials_name}
+
+        get_cac_token    
     fi
 
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+        log "One of the following required variables is missing: PCOIP_REGISTRATION_CODE, AD_SERVICE_ACCOUNT_PASSWORD, CAC_TOKEN"
         exit 1
     fi
 }
@@ -81,7 +106,7 @@ if [ ! -f $PCOIP_NETWORK_CONF_FILE ]; then
 fi
 
 
-# download CAC installer
+# Download CAC installer
 curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
 tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
 

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -20,13 +20,13 @@ variable "cam_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_registration_code" {
-  description = "PCoIP Registration code"
+variable "cam_credentials_file" {
+  description = "Location of GCP JSON credentials file"
   type        = string
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "pcoip_registration_code" {
+  description = "PCoIP Registration code"
   type        = string
 }
 


### PR DESCRIPTION
To support autoscaling of CAC's in the future, we will need to generate
new CAC tokens to be used during CAC installations. To generate new
CAC tokens, we have used a python script during startup on the CAC
which will CAM API calls using the user-provided CAM service account
credentials.

Both plaintext and encrypted secrets is supported for this single
connector deployment using CAM service account instead of CAC token.

Signed-off-by: Edwin Pau <epau@teradici.com>