### PR TITLE
gcp-kms-script

### DIFF
--- a/deployments/gcp/dc-only/terraform.tfvars.sample
+++ b/deployments/gcp/dc-only/terraform.tfvars.sample
@@ -1,4 +1,8 @@
 # Commented out lines represents defaults that can be changed
+####################
+#     General      #
+####################
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
@@ -17,19 +21,30 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 # Optional: additional AD users to create
 # domain_users_list = "/path/to/domain_users_list.csv"
 
-###############
-#   Secrets   #
-###############
+
+####################
+#      GCP KMS     #
+####################
 # The secrets below may be supplied in 2 formats:
 #   1. plain text
 #   2. KMS encrypted, base64 encoded
-# For option 1, leave "kms_cryptokey_id" commented out.
-# For option 2, set "kms_cryptokey_id" to the KMS key used to encrypt the
-# secrets. The GCP service account specified above in "gcp_service_account"
-# must be in the same project and have KMS decryptor permissions for this key.
+# For option 1, leave both keyring name and cryptokey name commented out.
+# For option 2, run the script located under tools using command "python3
+# gcp_kms_encrypto_secrets" which will overwrite this tfvars file with
+# your encrypted secrets and create an encrypted JSON for your CAM
+# credentials file. To set a custom keyring name and cryptokey name,
+# uncomment the two variables below and enter the new names, otherwise
+# a default name will be used by the script. The GCP service account 
+# specified above in "gcp_service_account" must be in the same project 
+# and have KMS decryptor permissions for this key.. 
 
-kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
+# kms_keyring_name   = "terraform-keyring"
+# kms_cryptokey_name = "terraform-cryptokey"
 
+
+####################
+#      Secrets     #
+####################
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name
 # 2. Must have 3 of the following categories:

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -1,4 +1,8 @@
 # Commented out lines represents defaults that can be changed
+####################
+#     General      #
+####################
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
@@ -17,6 +21,11 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 # Optional: additional AD users to create
 # domain_users_list = "/path/to/domain_users_list.csv"
 
+
+####################
+#        CAC       #
+####################
+
 # Specify the regions, zones and number of connectors to create per region.
 # For example:
 #   cac_region_list         = ["us-west1",    "europe-west4",   "asia-southeast1"]
@@ -34,6 +43,11 @@ cac_instance_count_list = []
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 ssl_key  = "/path/to/privkey.pem"
 ssl_cert = "/path/to/fullchain.pem"
+
+
+####################
+#   Workstations   #
+####################
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"
@@ -61,19 +75,29 @@ centos_std_instance_count = 0
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 
-###############
-#   Secrets   #
-###############
+
+####################
+#      GCP KMS     #
+####################
 # The secrets below may be supplied in 2 formats:
 #   1. plain text
 #   2. KMS encrypted, base64 encoded
-# For option 1, leave "kms_cryptokey_id" commented out.
-# For option 2, set "kms_cryptokey_id" to the KMS key used to encrypt the
-# secrets. The GCP service account specified above in "gcp_service_account"
-# must be in the same project and have KMS decryptor permissions for this key.
+# For option 1, comment out keyring name and cryptokey name
+# For option 2, set a name for for the keyring name and cryptokey name
+# An existing keyring and crypto key can also be used to encrypt secrets. 
+# The GCP service account specified above in "gcp_service_account" must be 
+# in the same project and have KMS decryptor permissions for this key. Run 
+# the script located under tools using command "python3 gcp_kms_encrypto_secrets" 
+# which will overwrite this tfvars file with your encrypted secrets and 
+# create an encrypted JSON for your CAM credentials file.
 
-kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
+kms_keyring_name   = "keyring-name"
+kms_cryptokey_name = "cryptokey-name"
 
+
+####################
+#      Secrets     #
+####################
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name
 # 2. Must have 3 of the following categories:
@@ -88,4 +112,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
+cam_credentials_file        = "/path/to/cred.json"

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -25,13 +25,13 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 ####################
 #        CAC       #
 ####################
-
 # Specify the regions, zones and number of connectors to create per region.
 # For example:
 #   cac_region_list         = ["us-west1",    "europe-west4",   "asia-southeast1"]
 #   cac_zone_list           = ["us-west1-b",  "europe-west4-b", "asia-southeast1-b"]
 #   cac_subnet_cidr_list    = ["10.0.1.0/24", "10.1.1.0/24",    "10.2.1.0/24"]
 #   cac_instance_count_list = [2,             3,                4]
+
 cac_region_list         = []
 cac_zone_list           = []
 cac_subnet_cidr_list    = []
@@ -48,6 +48,7 @@ ssl_cert = "/path/to/fullchain.pem"
 ####################
 #   Workstations   #
 ####################
+# Specify the number of workstations created for each type.
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"
@@ -82,17 +83,18 @@ centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # The secrets below may be supplied in 2 formats:
 #   1. plain text
 #   2. KMS encrypted, base64 encoded
-# For option 1, comment out keyring name and cryptokey name
-# For option 2, set a name for for the keyring name and cryptokey name
-# An existing keyring and crypto key can also be used to encrypt secrets. 
-# The GCP service account specified above in "gcp_service_account" must be 
-# in the same project and have KMS decryptor permissions for this key. Run 
-# the script located under tools using command "python3 gcp_kms_encrypto_secrets" 
-# which will overwrite this tfvars file with your encrypted secrets and 
-# create an encrypted JSON for your CAM credentials file.
+# For option 1, leave both keyring name and cryptokey name commented out.
+# For option 2, run the script located under tools using command "python3
+# gcp_kms_encrypto_secrets" which will overwrite this tfvars file with
+# your encrypted secrets and create an encrypted JSON for your CAM
+# credentials file. To set a custom keyring name and cryptokey name,
+# uncomment the two variables below and enter the new names, otherwise
+# a default name will be used by the script. The GCP service account 
+# specified above in "gcp_service_account" must be in the same project 
+# and have KMS decryptor permissions for this key.
 
-kms_keyring_name   = "keyring-name"
-kms_cryptokey_name = "cryptokey-name"
+# kms_keyring_name   = "terraform-keyring"
+# kms_cryptokey_name = "terraform-cryptokey"
 
 
 ####################

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -71,17 +71,18 @@ centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # The secrets below may be supplied in 2 formats:
 #   1. plain text
 #   2. KMS encrypted, base64 encoded
-# For option 1, comment out keyring name and cryptokey name
-# For option 2, set a name for for the keyring name and cryptokey name
-# An existing keyring and crypto key can also be used to encrypt secrets. 
-# The GCP service account specified above in "gcp_service_account" must be 
-# in the same project and have KMS decryptor permissions for this key. Run 
-# the script located under tools using command "python3 gcp_kms_encrypto_secrets" 
-# which will overwrite this tfvars file with your encrypted secrets and 
-# create an encrypted JSON for your CAM credentials file.
+# For option 1, leave both keyring name and cryptokey name commented out.
+# For option 2, run the script located under tools using command "python3
+# gcp_kms_encrypto_secrets" which will overwrite this tfvars file with
+# your encrypted secrets and create an encrypted JSON for your CAM
+# credentials file. To set a custom keyring name and cryptokey name,
+# uncomment the two variables below and enter the new names, otherwise
+# a default name will be used by the script. The GCP service account 
+# specified above in "gcp_service_account" must be in the same project 
+# and have KMS decryptor permissions for this key.. 
 
-kms_keyring_name   = "keyring-name"
-kms_cryptokey_name = "cryptokey-name"
+# kms_keyring_name   = "terraform-keyring"
+# kms_cryptokey_name = "terraform-cryptokey"
 
 
 ####################

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -1,4 +1,8 @@
 # Commented out lines represents defaults that can be changed
+####################
+#     General      #
+####################
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
@@ -17,6 +21,11 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 # Optional: additional AD users to create
 # domain_users_list = "/path/to/domain_users_list.csv"
 
+
+####################
+#        CAC       #
+####################
+
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
 # cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20191113"
@@ -24,6 +33,11 @@ cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # Optional: Specify SSL certificate for Connector
 # ssl_key  = "/path/to/privkey.pem"
 # ssl_cert = "/path/to/fullchain.pem"
+
+
+####################
+#   Workstations   #
+####################
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"
@@ -51,19 +65,28 @@ centos_std_instance_count = 0
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 
-###############
-#   Secrets   #
-###############
+####################
+#      GCP KMS     #
+####################
 # The secrets below may be supplied in 2 formats:
 #   1. plain text
 #   2. KMS encrypted, base64 encoded
-# For option 1, leave "kms_cryptokey_id" commented out.
-# For option 2, set "kms_cryptokey_id" to the KMS key used to encrypt the
-# secrets. The GCP service account specified above in "gcp_service_account"
-# must be in the same project and have KMS decryptor permissions for this key.
+# For option 1, comment out keyring name and cryptokey name
+# For option 2, set a name for for the keyring name and cryptokey name
+# An existing keyring and crypto key can also be used to encrypt secrets. 
+# The GCP service account specified above in "gcp_service_account" must be 
+# in the same project and have KMS decryptor permissions for this key. Run 
+# the script located under tools using command "python3 gcp_kms_encrypto_secrets" 
+# which will overwrite this tfvars file with your encrypted secrets and 
+# create an encrypted JSON for your CAM credentials file.
 
-kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
+kms_keyring_name   = "keyring-name"
+kms_cryptokey_name = "cryptokey-name"
 
+
+####################
+#      Secrets     #
+####################
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name
 # 2. Must have 3 of the following categories:
@@ -78,5 +101,5 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
+cam_credentials_file        = "/path/to/cred.json"
 

--- a/tools/gcp_kms_encrypt_secrets.py
+++ b/tools/gcp_kms_encrypt_secrets.py
@@ -5,36 +5,53 @@
 
 #!/usr/local/bin/python3
 
-from google.cloud import kms_v1
-from google.cloud.kms_v1 import enums
-import os
 import base64
 import json
-import ntpath
+from google.cloud.kms_v1 import enums
+from google.cloud        import kms_v1
+from google.oauth2       import service_account
+import os
 
-# Enter the path to the GCP credentials for the service account
-GCP_CREDENTIALS_FILE = "/path/to/gcp_cred.json"
+# Global variables
+GCP_CREDENTIALS_FILE = None
+CAM_CREDENTIALS_FILE = None
 
-# Enter the GCP project ID associated with the provided GCP service account
-PROJECT_ID = "your-project-1234"
+# Prompt user for deployment type (multi-region or single) and returns the path to the tfvars
+def get_tfvars_path():
+    validInput = False
+    deployment = None
 
-# Choose and enter new names for the key ring and crypto key.
-# Note: For security, keyring names cannot be changed or deleted once created.
-KEY_RING_ID = "create-a-key-ring-name"
-CRYPTO_KEY  = "create-a-crypto-key-name"
+    while not validInput:
+        deployment = input("Enter 0 or 1 for the deployment type:\n[0] for single-connector\n[1] for multi-region\n")
+        
+        if (deployment == "0") or (deployment == "1"):
+            validInput = True
+            print("")
 
-# Secrets to be encrypted using newly created crypto key
-DC_ADMIN_PASSWORD           = "SecuRe_pwd1"
-SAFE_MODE_ADMIN_PASSWORD    = "SecuRe_pwd2"
-AD_SERVICE_ACCOUNT_PASSWORD = "SecuRe_pwd3"
-PCOIP_REGISTRATION_CODE     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-CAM_CREDENTIALS_FILE        = "/path/to/cam_cred.json"
+    # Read the corresponding .tfvars file based on user selection
+    switcher = {
+        "0": "../deployments/gcp/single-connector/terraform.tfvars",
+        "1": "../deployments/gcp/multi-region/terraform.tfvars"
+    }
 
-# Set the location to use "global"
-LOCATION = "global"
+    return switcher.get(deployment)
 
-# Set environment variables to be used by KMS client
-os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_FILE
+
+# Read terraform.tfvars for user provided configurations
+def read_terraform_tfvars(tfvars_file):
+    # Declare an empty list
+    tf_data = {}
+
+    with open(tfvars_file, 'r') as f:
+        for line in f:
+            if line[0] in ('#', '\n'):
+                continue
+            
+            key, value = map(str.strip, line.split('='))
+            tf_data[key] = value
+
+    return tf_data
+
 
 # List KMS key rings
 def list_key_rings(client, project_id, location):
@@ -124,10 +141,6 @@ def encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_ke
     # CAM credentials file path to be encrypted
     cam_credentials_file = CAM_CREDENTIALS_FILE
 
-    # Directory and file name of CAM JSON credentials
-    cam_credentials_dirname  = ntpath.dirname(cam_credentials_file)
-    cam_credentials_basename = ntpath.basename(cam_credentials_file)
-
     # Encrypt CAM JSON credentials
     try:
         with open(cam_credentials_file) as cam_credentials:
@@ -136,7 +149,7 @@ def encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_ke
         cam_credentials_string = json.dumps(cam_credentials)
         cam_credentials_encrypted = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
                                     cam_credentials_string)
-        print("Encrypted CAM credentials:")
+        print("Encrypting CAM credentials...")
         print("{}\n".format(cam_credentials_encrypted))
 
         with open("{}.encrypted".format(cam_credentials_file), "w") as cam_credentials_encrypted_file:
@@ -148,24 +161,63 @@ def encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_ke
         print("")
 
 
-# Driver of this script
+# Write the new tfvars file using encrypted secrets
+def write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id):
+    lines = []
+    
+    with open(tfvars_file, 'r') as f:
+        for line in f:
+            if "kms_keyring_name" in line:
+                continue
+            if "kms_cryptokey_name" in line:
+                line = "kms_cryptokey_id = \"{}\"".format(kms_cryptokey_id)
+            if "dc_admin_password" in line:
+                line = "dc_admin_password           = \"{}\"".format(secrets.get("dc_admin_password"))
+            if "safe_mode_admin_password" in line:
+                line = "safe_mode_admin_password    = \"{}\"".format(secrets.get("safe_mode_admin_password"))
+            if "ad_service_account_password" in line:
+                line = "ad_service_account_password = \"{}\"".format(secrets.get("ad_service_account_password"))
+            if "pcoip_registration_code" in line:
+                line = "pcoip_registration_code     = \"{}\"".format(secrets.get("pcoip_registration_code"))    
+            if "cam_credentials_file" in line:
+                line = "cam_credentials_file        = \"{}.encrypted\"".format(CAM_CREDENTIALS_FILE)    
+            lines.append(line.rstrip())
+    
+    # Rewrite the existing terraform.tfvars
+    with open("terraform.tfvars", 'w') as f:
+        f.writelines("%s\n" %line for line in lines)
+
+
 def main():
+    # Path to tfvars depends on user input (multi or single)
+    tfvars_file = get_tfvars_path()
+    
+    # Read tfvars file into a dictionary
+    tfvars = read_terraform_tfvars(tfvars_file)
+
+    # Set global variables using tfvars file
+    global GCP_CREDENTIALS_FILE
+    GCP_CREDENTIALS_FILE = tfvars.get("gcp_credentials_file").replace('\"', '')
+    global CAM_CREDENTIALS_FILE
+    CAM_CREDENTIALS_FILE = tfvars.get("cam_credentials_file").replace('\"', '')
+
     # Create an API client for the KMS API using the provided GCP service account
-    client = kms_v1.KeyManagementServiceClient()
+    credentials     = service_account.Credentials.from_service_account_file(GCP_CREDENTIALS_FILE)
+    client          = kms_v1.KeyManagementServiceClient( credentials = credentials )
 
-    # Resource names of the location associated with the key rings
-    project_id    = PROJECT_ID
-    key_ring_id   = KEY_RING_ID
-    crypto_key_id = CRYPTO_KEY
-    location      = LOCATION
-
-    # Secrets in plaintext
+    # Secrets in plaintext to be encrypted
     secrets = {
-        "dc_admin_password"           : DC_ADMIN_PASSWORD,
-        "safe_mode_admin_password"    : SAFE_MODE_ADMIN_PASSWORD,
-        "ad_service_account_password" : AD_SERVICE_ACCOUNT_PASSWORD,
-        "pcoip_registration_code"     : PCOIP_REGISTRATION_CODE
+        "dc_admin_password"           : tfvars.get("dc_admin_password"),
+        "safe_mode_admin_password"    : tfvars.get("safe_mode_admin_password"),
+        "ad_service_account_password" : tfvars.get("ad_service_account_password"),
+        "pcoip_registration_code"     : tfvars.get("pcoip_registration_code")
     }
+    
+    # GCP KMS resource variables
+    project_id       = tfvars.get("gcp_project_id").replace('\"', '')
+    key_ring_id      = tfvars.get("kms_keyring_name").replace('\"', '')
+    crypto_key_id    = tfvars.get("kms_cryptokey_name").replace('\"', '')
+    location         = "global"
 
     # Create a key ring
     try:
@@ -189,16 +241,15 @@ def main():
         print("An exception occurred creating new crypto key:")
         print(err)
         print("")
-    
+
     # Encrypt secrets including CAM credentials
     try:
         for secret in secrets:
             print("Encrypting {}...".format(secret))
-
             print("{0}: {1}".format(secret, secrets.get(secret)))
-
             ciphertext = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id, secrets.get(secret))
             print("{0}: {1}\n".format(secret, ciphertext))
+            secrets[secret] = ciphertext
 
         encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_key_id)
             
@@ -206,7 +257,10 @@ def main():
         print("An exception occurred encrypting secrets:")
         print(err)
         print("")
-      
+
+    # Write secrets into new terraform.tfvars file
+    kms_cryptokey_id = client.crypto_key_path_path(project_id, location, key_ring_id, crypto_key_id)
+    write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id)
 
 # Entry point to this script
 if __name__ == '__main__':

--- a/tools/gcp_kms_encrypt_secrets.py
+++ b/tools/gcp_kms_encrypt_secrets.py
@@ -5,6 +5,7 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
 import base64
 import json
 import os
@@ -300,7 +301,25 @@ def write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id):
 
 
 def main():
-    encrypt_tfvars_secrets()
+    parser = argparse.ArgumentParser(description="This script encrypts or decrypts the secrets  \
+                                    inside the user-specified terraform.tfstate file by         \
+                                    prompting the user for one of the three deployment types    \
+                                    (single, multi-region, dc-only). Select the mode by setting \
+                                    a flag: -e for encryption or -d for decryption")
+
+    parser.add_argument("-e", help="run this script in encryption mode", action='store_true')
+    parser.add_argument("-d", help="run this script in decryption mode", action='store_true')
+
+    args = parser.parse_args()
+    
+    if args.e:
+        print("Encrypting tfvars secrets...")
+        encrypt_tfvars_secrets()
+    elif args.d:
+        print("Decrypting tfvars secrets...")
+        #decrypt_tfvars_secrets()
+    else:
+        print("[gcp_kms_encrypt_secrets.py] No mode selected, please set a flag. -e for encryption or -d for decryption")
 
 
 # Entry point to this script

--- a/tools/gcp_kms_encrypt_secrets.py
+++ b/tools/gcp_kms_encrypt_secrets.py
@@ -1,86 +1,21 @@
+#!/usr/bin/python3
+
 # Copyright (c) 2020 Teradici Corporation
 #
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
-#!/usr/local/bin/python3
-
 import base64
 import json
-from google.cloud.kms_v1 import enums
-from google.cloud        import kms_v1
-from google.oauth2       import service_account
 import os
+from google.cloud        import kms_v1
+from google.cloud.kms_v1 import enums
+from google.oauth2       import service_account
+from urllib.error        import HTTPError
 
 # Global variables
 GCP_CREDENTIALS_FILE = None
 CAM_CREDENTIALS_FILE = None
-
-# Prompt user for deployment type (multi-region or single) and returns the path to the tfvars
-def get_tfvars_path():
-    validInput = False
-    deployment = None
-
-    while not validInput:
-        deployment = input("Enter 0 or 1 for the deployment type:\n[0] for single-connector\n[1] for multi-region\n")
-        
-        if (deployment == "0") or (deployment == "1"):
-            validInput = True
-            print("")
-
-    # Read the corresponding .tfvars file based on user selection
-    switcher = {
-        "0": "../deployments/gcp/single-connector/terraform.tfvars",
-        "1": "../deployments/gcp/multi-region/terraform.tfvars"
-    }
-
-    return switcher.get(deployment)
-
-
-# Read terraform.tfvars for user provided configurations
-def read_terraform_tfvars(tfvars_file):
-    # Declare an empty list
-    tf_data = {}
-
-    with open(tfvars_file, 'r') as f:
-        for line in f:
-            if line[0] in ('#', '\n'):
-                continue
-            
-            key, value = map(str.strip, line.split('='))
-            tf_data[key] = value
-
-    return tf_data
-
-
-# List KMS key rings
-def list_key_rings(client, project_id, location):
-    parent        = client.location_path(project_id, location)
-    response      = client.list_key_rings(parent)
-    response_list = list(response)
-
-    if len(response_list) > 0:
-        print("Key rings:")
-        for key_ring in response_list:
-            print(key_ring.name)
-        print("")
-    else:
-        print("No key rings found.\n")
-
-
-# Create KMS key ring
-def create_key_ring(client, project_id, location, key_ring_id):
-    parent = client.location_path(project_id, location)
-
-    # The key ring object template
-    keyring_path = client.key_ring_path(project_id, location, key_ring_id)
-    keyring      = { "name": keyring_path }
-
-    # Create a key ring
-    response = client.create_key_ring(parent, key_ring_id, keyring)
-
-    return response.name
-
 
 # Create crypto key within a key ring
 def create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id):
@@ -95,24 +30,19 @@ def create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id):
 
     return response.name
 
-
-# Encrypt plaintext data using the provided symmetric crypto key
-def encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
-                      plaintext):
-    # Resource path of the crypto key
-    crypto_key_path = client.crypto_key_path_path(project_id, location, key_ring_id, 
-                        crypto_key_id)
-
-    # UTF-8 encoding of plaintext
-    plaintext = plaintext.encode("utf-8")
-
-    # Use the KMS API to encrypt the data.
-    response = client.encrypt(crypto_key_path, plaintext)
-
-    # Base64 encoding of ciphertext
-    ciphertext = base64.b64encode(response.ciphertext).decode()
     
-    return ciphertext
+# Create KMS key ring
+def create_key_ring(client, project_id, location, key_ring_id):
+    parent = client.location_path(project_id, location)
+
+    # The key ring object template
+    keyring_path = client.key_ring_path(project_id, location, key_ring_id)
+    keyring      = {"name": keyring_path}
+
+    # Create a key ring
+    response = client.create_key_ring(parent, key_ring_id, keyring)
+
+    return response.name
 
 
 # Decrypt ciphertext using the provided symmetric crypto key
@@ -143,22 +73,202 @@ def encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_ke
 
     # Encrypt CAM JSON credentials
     try:
+        print("Encrypting CAM credentials...\n")
+        
         with open(cam_credentials_file) as cam_credentials:
             cam_credentials = json.load(cam_credentials)
     
         cam_credentials_string = json.dumps(cam_credentials)
-        cam_credentials_encrypted = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
-                                    cam_credentials_string)
-        print("Encrypting CAM credentials...")
-        print("{}\n".format(cam_credentials_encrypted))
+        cam_credentials_encrypted = encrypt_plaintext(client, project_id, location, key_ring_id, 
+                                    crypto_key_id, cam_credentials_string)
+        
+        print("Finished encrypting CAM credentials:\n{}\n".format(cam_credentials_encrypted))
 
         with open("{}.encrypted".format(cam_credentials_file), "w") as cam_credentials_encrypted_file:
             cam_credentials_encrypted_file.write(cam_credentials_encrypted)
-            
+
     except Exception as err:
         print("An exception occurred encrypting CAM JSON credentials:")
-        print(err)
+        print("{}\n".format(err))
+
+
+# Encrypt plaintext data using the provided symmetric crypto key
+def encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
+                      plaintext):
+    # Resource path of the crypto key
+    crypto_key_path = client.crypto_key_path_path(project_id, location, key_ring_id, 
+                        crypto_key_id)
+
+    # UTF-8 encoding of plaintext
+    plaintext = plaintext.encode("utf-8")
+
+    # Use the KMS API to encrypt the data.
+    response = client.encrypt(crypto_key_path, plaintext)
+
+    # Base64 encoding of ciphertext
+    ciphertext = base64.b64encode(response.ciphertext).decode()
+    
+    return ciphertext
+
+
+def encrypt_tfvars_secrets():
+    # Path to the tfvars file depends on user input (single, multi, or dc-only)
+    tfvars_path = get_tfvars_path()
+    
+    # Read tfvars file into a dictionary
+    tfvars_dict = read_terraform_tfvars(tfvars_path)
+
+    # Abort the encryption if the tfvars is already encrypted
+    if tfvars_dict.get("kms_cryptokey_id"):
+        raise SystemExit()
+
+    # Get the secrets to be encrypted inside the tfvars file
+    secrets = get_tfvars_secrets(tfvars_dict, tfvars_path)
+
+    # Set GCP credentials global variable for the client
+    global GCP_CREDENTIALS_FILE
+    GCP_CREDENTIALS_FILE = tfvars_dict.get("gcp_credentials_file").replace('\"', '')
+
+    # Create an API client for the KMS API using the provided GCP service account
+    credentials = service_account.Credentials.from_service_account_file(GCP_CREDENTIALS_FILE)
+    client      = kms_v1.KeyManagementServiceClient(credentials = credentials)
+
+    # GCP KMS resource variables
+    project_id = tfvars_dict.get("gcp_project_id").replace('\"', '')
+    location   = "global"
+
+    if tfvars_dict.get("kms_keyring_name")   == None or \
+       tfvars_dict.get("kms_cryptokey_name") == None:
+        key_ring_id   = "terraform-keyring"
+        crypto_key_id = "terraform-cryptokey"
+    else:
+        key_ring_id   = tfvars_dict.get("kms_keyring_name").replace('\"', '')
+        crypto_key_id = tfvars_dict.get("kms_cryptokey_name").replace('\"', '')
+
+    # List all key rings
+    list_key_rings(client, project_id, location)
+
+    # Create the key ring
+    try:
+        kms_keyring_id = create_key_ring(client, project_id, location, key_ring_id)
+        print("Created key ring: {}\n".format(kms_keyring_id))
+    
+    except Exception as err:
+        print("An exception occurred creating new key ring:")
+        print("{}".format(err))
+        print("Using existing key ring: {}\n".format(key_ring_id))
+
+    # Create a crypto key
+    try:
+        kms_cryptokey_id = create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id)
+        print("kms_cryptokey_id: {}\n".format(kms_cryptokey_id))
+
+    except Exception as err:
+        print("An exception occurred creating new crypto key:")
+        print("{}".format(err))
+        print("Using existing crypto key: {}\n".format(crypto_key_id))
+
+    # Encrypt secrets including CAM credentials
+    try:
+        for secret in secrets:
+            print("Encrypting {}...\n".format(secret))
+            ciphertext = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id, secrets.get(secret))
+            print("Finished encrypting {0}:\n{1}\n".format(secret, ciphertext))
+            secrets[secret] = ciphertext
+
+        if tfvars_dict.get("cam_credentials_file"):
+            encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_key_id)
+            
+    except Exception as err:
+        print("An exception occurred encrypting secrets:")
+        print("{}\n".format(err))
+
+    # Write secrets into new terraform.tfvars file
+    kms_cryptokey_id = client.crypto_key_path_path(project_id, location, key_ring_id, crypto_key_id)
+    write_new_tfvars(tfvars_path, secrets, kms_cryptokey_id)
+
+
+# Prompt user for deployment type (multi-region or single) and returns the path to the tfvars
+def get_tfvars_path():
+    validInput = False
+    deployment = None
+
+    while not validInput:
+        deployment = input("Enter 0, 1, or 2 for the deployment type:\n" \
+                           "[0] for single-connector\n" \
+                           "[1] for multi-region\n" \
+                           "[2] for dc-only\n")
+        
+        if deployment == "0" or deployment == "1" or deployment == "2":
+            validInput = True
+            print("")
+
+    # Read the corresponding .tfvars file based on user selection
+    switcher = {
+        "0": "../deployments/gcp/single-connector/terraform.tfvars",
+        "1": "../deployments/gcp/multi-region/terraform.tfvars",
+        "2": "../deployments/gcp/dc-only/terraform.tfvars"
+    }
+
+    return switcher.get(deployment)
+
+
+
+def get_tfvars_secrets(tfvars_dict, tfvars_path):
+    secrets = {}
+    
+    if "dc-only" in tfvars_path:
+        # Secrets in plaintext to be encrypted for dc-only
+        secrets = {
+            "dc_admin_password"           : tfvars_dict.get("dc_admin_password"),
+            "safe_mode_admin_password"    : tfvars_dict.get("safe_mode_admin_password"),
+            "ad_service_account_password" : tfvars_dict.get("ad_service_account_password")
+        }
+
+    else:
+        # Secrets in plaintext to be encrypted for single and multi-region
+        secrets = {
+            "dc_admin_password"           : tfvars_dict.get("dc_admin_password"),
+            "safe_mode_admin_password"    : tfvars_dict.get("safe_mode_admin_password"),
+            "ad_service_account_password" : tfvars_dict.get("ad_service_account_password"),
+            "pcoip_registration_code"     : tfvars_dict.get("pcoip_registration_code")
+        }
+
+        global CAM_CREDENTIALS_FILE
+        CAM_CREDENTIALS_FILE = tfvars_dict.get("cam_credentials_file").replace('\"', '')
+
+    return secrets
+
+
+# List KMS key rings
+def list_key_rings(client, project_id, location):
+    parent        = client.location_path(project_id, location)
+    response      = client.list_key_rings(parent)
+    response_list = list(response)
+
+    if len(response_list) > 0:
+        print("Key rings in project:")
+        for key_ring in response_list:
+            print(key_ring.name)
         print("")
+    else:
+        print("No key rings found.\n")
+
+
+# Read terraform.tfvars for user provided configurations
+def read_terraform_tfvars(tfvars_file):
+    # Declare an empty list
+    tf_data = {}
+
+    with open(tfvars_file, 'r') as f:
+        for line in f:
+            if line[0] in ('#', '\n'):
+                continue
+            
+            key, value = map(str.strip, line.split('='))
+            tf_data[key] = value
+
+    return tf_data
 
 
 # Write the new tfvars file using encrypted secrets
@@ -180,7 +290,8 @@ def write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id):
             if "pcoip_registration_code" in line:
                 line = "pcoip_registration_code     = \"{}\"".format(secrets.get("pcoip_registration_code"))    
             if "cam_credentials_file" in line:
-                line = "cam_credentials_file        = \"{}.encrypted\"".format(CAM_CREDENTIALS_FILE)    
+                line = "cam_credentials_file        = \"{}.encrypted\"".format(CAM_CREDENTIALS_FILE)
+
             lines.append(line.rstrip())
     
     # Rewrite the existing terraform.tfvars
@@ -189,78 +300,8 @@ def write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id):
 
 
 def main():
-    # Path to tfvars depends on user input (multi or single)
-    tfvars_file = get_tfvars_path()
-    
-    # Read tfvars file into a dictionary
-    tfvars = read_terraform_tfvars(tfvars_file)
+    encrypt_tfvars_secrets()
 
-    # Set global variables using tfvars file
-    global GCP_CREDENTIALS_FILE
-    GCP_CREDENTIALS_FILE = tfvars.get("gcp_credentials_file").replace('\"', '')
-    global CAM_CREDENTIALS_FILE
-    CAM_CREDENTIALS_FILE = tfvars.get("cam_credentials_file").replace('\"', '')
-
-    # Create an API client for the KMS API using the provided GCP service account
-    credentials     = service_account.Credentials.from_service_account_file(GCP_CREDENTIALS_FILE)
-    client          = kms_v1.KeyManagementServiceClient( credentials = credentials )
-
-    # Secrets in plaintext to be encrypted
-    secrets = {
-        "dc_admin_password"           : tfvars.get("dc_admin_password"),
-        "safe_mode_admin_password"    : tfvars.get("safe_mode_admin_password"),
-        "ad_service_account_password" : tfvars.get("ad_service_account_password"),
-        "pcoip_registration_code"     : tfvars.get("pcoip_registration_code")
-    }
-    
-    # GCP KMS resource variables
-    project_id       = tfvars.get("gcp_project_id").replace('\"', '')
-    key_ring_id      = tfvars.get("kms_keyring_name").replace('\"', '')
-    crypto_key_id    = tfvars.get("kms_cryptokey_name").replace('\"', '')
-    location         = "global"
-
-    # Create a key ring
-    try:
-        kms_keyring_id = create_key_ring(client, project_id, location, key_ring_id)
-        print("Created key ring: {}\n".format(kms_keyring_id))
-
-    except Exception as err:
-        print("An exception occurred creating new key ring:")
-        print(err)
-        print("")
-
-    # List all key rings
-    list_key_rings(client, project_id, location)
-
-    # Create a crypto key
-    try:
-        kms_cryptokey_id = create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id)
-        print("kms_cryptokey_id: {}\n".format(kms_cryptokey_id))
-
-    except Exception as err:
-        print("An exception occurred creating new crypto key:")
-        print(err)
-        print("")
-
-    # Encrypt secrets including CAM credentials
-    try:
-        for secret in secrets:
-            print("Encrypting {}...".format(secret))
-            print("{0}: {1}".format(secret, secrets.get(secret)))
-            ciphertext = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id, secrets.get(secret))
-            print("{0}: {1}\n".format(secret, ciphertext))
-            secrets[secret] = ciphertext
-
-        encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_key_id)
-            
-    except Exception as err:
-        print("An exception occurred encrypting secrets:")
-        print(err)
-        print("")
-
-    # Write secrets into new terraform.tfvars file
-    kms_cryptokey_id = client.crypto_key_path_path(project_id, location, key_ring_id, crypto_key_id)
-    write_new_tfvars(tfvars_file, secrets, kms_cryptokey_id)
 
 # Entry point to this script
 if __name__ == '__main__':

--- a/tools/gcp_kms_encrypt_secrets.py
+++ b/tools/gcp_kms_encrypt_secrets.py
@@ -1,0 +1,213 @@
+# Copyright (c) 2020 Teradici Corporation
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+#!/usr/local/bin/python3
+
+from google.cloud import kms_v1
+from google.cloud.kms_v1 import enums
+import os
+import base64
+import json
+import ntpath
+
+# Enter the path to the GCP credentials for the service account
+GCP_CREDENTIALS_FILE = "/path/to/gcp_cred.json"
+
+# Enter the GCP project ID associated with the provided GCP service account
+PROJECT_ID = "your-project-1234"
+
+# Choose and enter new names for the key ring and crypto key.
+# Note: For security, keyring names cannot be changed or deleted once created.
+KEY_RING_ID = "create-a-key-ring-name"
+CRYPTO_KEY  = "create-a-crypto-key-name"
+
+# Secrets to be encrypted using newly created crypto key
+DC_ADMIN_PASSWORD           = "SecuRe_pwd1"
+SAFE_MODE_ADMIN_PASSWORD    = "SecuRe_pwd2"
+AD_SERVICE_ACCOUNT_PASSWORD = "SecuRe_pwd3"
+PCOIP_REGISTRATION_CODE     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
+CAM_CREDENTIALS_FILE        = "/path/to/cam_cred.json"
+
+# Set the location to use "global"
+LOCATION = "global"
+
+# Set environment variables to be used by KMS client
+os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = GCP_CREDENTIALS_FILE
+
+# List KMS key rings
+def list_key_rings(client, project_id, location):
+    parent        = client.location_path(project_id, location)
+    response      = client.list_key_rings(parent)
+    response_list = list(response)
+
+    if len(response_list) > 0:
+        print("Key rings:")
+        for key_ring in response_list:
+            print(key_ring.name)
+        print("")
+    else:
+        print("No key rings found.\n")
+
+
+# Create KMS key ring
+def create_key_ring(client, project_id, location, key_ring_id):
+    parent = client.location_path(project_id, location)
+
+    # The key ring object template
+    keyring_path = client.key_ring_path(project_id, location, key_ring_id)
+    keyring      = { "name": keyring_path }
+
+    # Create a key ring
+    response = client.create_key_ring(parent, key_ring_id, keyring)
+
+    return response.name
+
+
+# Create crypto key within a key ring
+def create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id):
+    parent = client.key_ring_path(project_id, location, key_ring_id)
+
+    # Create the crypto key object template
+    purpose    = enums.CryptoKey.CryptoKeyPurpose.ENCRYPT_DECRYPT
+    crypto_key = { "purpose": purpose }
+
+    # Create a crypto key for the given key ring
+    response = client.create_crypto_key(parent, crypto_key_id, crypto_key)
+
+    return response.name
+
+
+# Encrypt plaintext data using the provided symmetric crypto key
+def encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
+                      plaintext):
+    # Resource path of the crypto key
+    crypto_key_path = client.crypto_key_path_path(project_id, location, key_ring_id, 
+                        crypto_key_id)
+
+    # UTF-8 encoding of plaintext
+    plaintext = plaintext.encode("utf-8")
+
+    # Use the KMS API to encrypt the data.
+    response = client.encrypt(crypto_key_path, plaintext)
+
+    # Base64 encoding of ciphertext
+    ciphertext = base64.b64encode(response.ciphertext).decode()
+    
+    return ciphertext
+
+
+# Decrypt ciphertext using the provided symmetric crypto key
+def decrypt_ciphertext(client, project_id, location, key_ring_id, crypto_key_id,
+                      ciphertext):
+    # Resource name of the crypto key
+    crypto_key_path = client.crypto_key_path_path(project_id, location, key_ring_id,
+                        crypto_key_id)
+
+    # UTF-8 encoding of ciphertext
+    ciphertext = ciphertext.encode("utf-8")
+
+    # Base64 decoding of ciphertext
+    ciphertext = base64.b64decode(ciphertext)
+
+    # Use the KMS API to decrypt the data.
+    response = client.decrypt(crypto_key_path, ciphertext)
+
+    # Decode Base64 plaintext
+    plaintext = response.plaintext.decode()
+    return plaintext
+
+
+# Encrypt CAM JSON credential file
+def encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_key_id):
+    # CAM credentials file path to be encrypted
+    cam_credentials_file = CAM_CREDENTIALS_FILE
+
+    # Directory and file name of CAM JSON credentials
+    cam_credentials_dirname  = ntpath.dirname(cam_credentials_file)
+    cam_credentials_basename = ntpath.basename(cam_credentials_file)
+
+    # Encrypt CAM JSON credentials
+    try:
+        with open(cam_credentials_file) as cam_credentials:
+            cam_credentials = json.load(cam_credentials)
+    
+        cam_credentials_string = json.dumps(cam_credentials)
+        cam_credentials_encrypted = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id,
+                                    cam_credentials_string)
+        print("Encrypted CAM credentials:")
+        print("{}\n".format(cam_credentials_encrypted))
+
+        with open("{}.encrypted".format(cam_credentials_file), "w") as cam_credentials_encrypted_file:
+            cam_credentials_encrypted_file.write(cam_credentials_encrypted)
+            
+    except Exception as err:
+        print("An exception occurred encrypting CAM JSON credentials:")
+        print(err)
+        print("")
+
+
+# Driver of this script
+def main():
+    # Create an API client for the KMS API using the provided GCP service account
+    client = kms_v1.KeyManagementServiceClient()
+
+    # Resource names of the location associated with the key rings
+    project_id    = PROJECT_ID
+    key_ring_id   = KEY_RING_ID
+    crypto_key_id = CRYPTO_KEY
+    location      = LOCATION
+
+    # Secrets in plaintext
+    secrets = {
+        "dc_admin_password"           : DC_ADMIN_PASSWORD,
+        "safe_mode_admin_password"    : SAFE_MODE_ADMIN_PASSWORD,
+        "ad_service_account_password" : AD_SERVICE_ACCOUNT_PASSWORD,
+        "pcoip_registration_code"     : PCOIP_REGISTRATION_CODE
+    }
+
+    # Create a key ring
+    try:
+        kms_keyring_id = create_key_ring(client, project_id, location, key_ring_id)
+        print("Created key ring: {}\n".format(kms_keyring_id))
+
+    except Exception as err:
+        print("An exception occurred creating new key ring:")
+        print(err)
+        print("")
+
+    # List all key rings
+    list_key_rings(client, project_id, location)
+
+    # Create a crypto key
+    try:
+        kms_cryptokey_id = create_crypto_key(client, project_id, location, key_ring_id, crypto_key_id)
+        print("kms_cryptokey_id: {}\n".format(kms_cryptokey_id))
+
+    except Exception as err:
+        print("An exception occurred creating new crypto key:")
+        print(err)
+        print("")
+    
+    # Encrypt secrets including CAM credentials
+    try:
+        for secret in secrets:
+            print("Encrypting {}...".format(secret))
+
+            print("{0}: {1}".format(secret, secrets.get(secret)))
+
+            ciphertext = encrypt_plaintext(client, project_id, location, key_ring_id, crypto_key_id, secrets.get(secret))
+            print("{0}: {1}\n".format(secret, ciphertext))
+
+        encrypt_cam_credentials(client, project_id, location, key_ring_id, crypto_key_id)
+            
+    except Exception as err:
+        print("An exception occurred encrypting secrets:")
+        print(err)
+        print("")
+      
+
+# Entry point to this script
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
- Updated README section under Encrypting Secrets with instructions on how to use the script
- Left the original section in as that would still work for the experienced that just want to manipulate tfvars themselves.
- Addressed the comments in the previous review
- Script parses tfvars for secrets it needs and outputs a tfvars with ciphertext instead of plaintext
- Used argparse as suggested. -e flag for encryption mode and -d flag for decryption mode
- Script supports all three deployment types