### PR TITLE
Use CAM service account

### DIFF
--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -60,8 +60,8 @@ module "cac-igm" {
   gcp_service_account     = var.gcp_service_account
   kms_cryptokey_id        = var.kms_cryptokey_id
   cam_url                 = var.cam_url
+  cam_credentials_file    = var.cam_credentials_file
   pcoip_registration_code = var.pcoip_registration_code
-  cac_token               = var.cac_token
 
   domain_name                 = var.domain_name
   domain_controller_ip        = module.dc.internal-ip

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -72,7 +72,7 @@ centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # secrets. The GCP service account specified above in "gcp_service_account"
 # must be in the same project and have KMS decryptor permissions for this key.
 
-kms_cryptokey_id  = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
+kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
 
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -1,5 +1,5 @@
 # Commented out lines represents defaults that can be changed
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west1"
@@ -72,7 +72,7 @@ centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # secrets. The GCP service account specified above in "gcp_service_account"
 # must be in the same project and have KMS decryptor permissions for this key.
 
-kms_cryptokey_id = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
+kms_cryptokey_id  = "projects/<project-id>/locations/<location>/keyRings/<keyring-name>/cryptoKeys/<key-name>"
 
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name
@@ -88,4 +88,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
+cam_credentials_file        = "/path/to/cam_cred.json"

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -174,11 +174,6 @@ variable "ws_subnet_cidr" {
   default     = "10.0.2.0/24"
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
-  type        = string
-}
-
 variable "pcoip_registration_code" {
   description = "PCoIP Registration code"
   type        = string
@@ -187,6 +182,11 @@ variable "pcoip_registration_code" {
 variable "cam_url" {
   description = "cam server url."
   default     = "https://cam.teradici.com"
+}
+
+variable "cam_credentials_file" {
+  description = "Location of CAM JSON credentials file"
+  type        = string
 }
 
 variable "enable_workstation_public_ip" {

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -60,8 +60,8 @@ module "cac" {
   gcp_service_account     = var.gcp_service_account
   kms_cryptokey_id        = var.kms_cryptokey_id
   cam_url                 = var.cam_url
+  cam_credentials_file    = var.cam_credentials_file
   pcoip_registration_code = var.pcoip_registration_code
-  cac_token               = var.cac_token
 
   domain_name                 = var.domain_name
   domain_controller_ip        = module.dc.internal-ip

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -1,5 +1,5 @@
 # Commented out lines represents defaults that can be changed
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west1"
@@ -78,5 +78,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
-
+cam_credentials_file        = "/path/to/cam_cred.json"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -154,11 +154,6 @@ variable "ws_subnet_cidr" {
   default     = "10.0.2.0/24"
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
-  type        = string
-}
-
 variable "pcoip_registration_code" {
   description = "PCoIP Registration code"
   type        = string
@@ -167,6 +162,11 @@ variable "pcoip_registration_code" {
 variable "cam_url" {
   description = "cam server url."
   default     = "https://cam.teradici.com"
+}
+
+variable "cam_credentials_file" {
+  description = "Location of CAM JSON credentials file"
+  type        = string
 }
 
 variable "enable_workstation_public_ip" {

--- a/modules/gcp/cac-igm/cac-cam.py
+++ b/modules/gcp/cac-igm/cac-cam.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2020 Teradici Corporation
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+import os
+import requests
+import sys
+
+API_URL = None
+
+def create_connector_name():
+    """A function to create a custom connector name
+    
+    Uses metadata server to access instance data, which is used to create the connector name.
+    
+    Returns:
+        string: a string for the connector name
+    """
+
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/"
+    headers      = {"Metadata-Flavor": "Google"}
+
+    response_zone = requests.get(metadata_url + "zone", headers = headers)
+    response_name = requests.get(metadata_url + "name", headers = headers)
+
+    zone = response_zone.text.rpartition('/')[2]
+    name = response_name.text
+
+    connector_name = "{}-{}".format(zone, name)
+    
+    return connector_name
+
+
+def get_auth_token(filepath):
+    """A function to retrieve a CAM authentication token
+    
+    Uses a CAM credentials JSON file to request a CAM authentication token.
+    
+    Args:
+        filepath (str): the file location of CAM credentials JSON
+
+    Returns:
+        string: a string for the CAM authentication token
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM credentials file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    request_body = dict(username = cam_credentials.get('username'), 
+                        password = cam_credentials.get('apiKey'),
+                        tenantId = cam_credentials.get('tenantId'))
+
+    response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body = response.json()
+    auth_token    = response_body.get('data').get('token')
+
+    return auth_token
+
+
+def get_deployment_id(filepath):
+    """A function to parse the deployment ID
+    
+    Parses the deployment ID from the CAM credentials JSON
+    
+    Args:
+        filepath (str): the file location of CAM credentials JSON
+
+    Returns:
+        string: a string for the deployment ID
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM credentials file. Exiting CAM script...\n{}".format(err))
+        raise ex
+    
+    return cam_credentials.get('deploymentId')
+
+
+def get_cac_token(auth_token, deployment_id, connector_name):
+    """A function that creates a connector token
+    
+    Parses the deployment ID from the CAM credentials JSON
+    
+    Args:
+        auth_token (str): the file location of CAM credentials JSON
+        deployment_id (str): a string for the deployment ID
+        connector_name (str): a string for the connector name
+
+    Returns:
+        string: a string for the connector token
+    """
+
+    session = requests.Session()
+    session.headers.update({"Authorization": auth_token})
+
+    body = dict(deploymentId  = deployment_id, 
+                connectorName = connector_name)
+
+    response = session.post("{}/auth/tokens/connector".format(API_URL), json=body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body   = response.json()
+    connector_token = response_body.get('data').get('token')
+
+    return connector_token
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This script uses CAM credentials to create a new connector token.")
+
+    parser.add_argument("cam", help="specify the path to CAM credentials file")
+    parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
+    args = parser.parse_args()
+
+    # Allow user to override default CAM URL
+    global API_URL
+    API_URL = args.url
+
+    auth_token     = get_auth_token(args.cam)
+    deployment_id  = get_deployment_id(args.cam)
+    connector_name = create_connector_name()
+    cac_token      = get_cac_token(auth_token, deployment_id, connector_name)
+
+    return cac_token
+
+
+if __name__ == '__main__':
+    try:
+        # Print the cac_token string as the output of this script
+        print(main())
+    except:
+        # Prevent bash from interpreting any error messages
+        sys.exit(1)
+

--- a/modules/gcp/cac-igm/cac-startup.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-startup.sh.tmpl
@@ -18,29 +18,12 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$INSTALL_LOG"
 }
 
-get_cac_token() {
-    echo '### Retrieve connector token before CAC install ###'
-    log "Retrieving connector token..."
-
-    # Download the CAM python script from the bucket and run it to create a cac token
-    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
-    chmod +x ${cam_script}
-
-    # Set CAC_TOKEN variable using the script's output
-    CAC_TOKEN=`./${cam_script} ${cam_credentials_file}`
-
-    # Check and exit startup script if retrieving connector token failed
-    if [ $? -ne 0 ]; then
-        log "Failed to retrieve connector token. Exiting startup script..."
-        exit 1
-    fi
-}
-
+# Retrieves credentials required to install the connector
 get_credentials() {
-    # Download the CAM credentials JSON file from the bucket
+    log "Downloading CAM credentials JSON file from the bucket..."
     gsutil cp gs://${bucket_name}/${cam_credentials_file} $INSTALL_DIR
 
-    # Download and install python, python3
+    log "Installing Python and Python3..."
     apt-get -qq update
     apt install -y python
     apt install -y python3
@@ -52,13 +35,14 @@ get_credentials() {
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
 
     else
-        log "Using encryption key ${kms_cryptokey_id}..."
+        log "Using encryption key: ${kms_cryptokey_id}..."
 
         # Gets access token attribute of response json object
         token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" \
                                           | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
 
         # Gets data using access token and decodes it
+        log "Decrypting PCoIP registration code..."
         data=$(echo "{ \"ciphertext\": \"${pcoip_registration_code}\" }")
         b64_data=$(curl -X POST \
                         -d "$data" "$DECRYPT_URI" \
@@ -67,6 +51,7 @@ get_credentials() {
                         | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
+        log "Decrypting AD service account password..."
         data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
         b64_data=$(curl -X POST \
                         -d "$data" "$DECRYPT_URI" \
@@ -75,10 +60,11 @@ get_credentials() {
                         | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
+        log "Decrypting CAM service account credentials..."
         # Gets decrypted CAM service account credentials and outputs to plaintext json file
         cam_cred_encrypted=$(cat ${cam_credentials_file})
         data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
-        b64_data=$(curl -X POST 
+        b64_data=$(curl -X POST \
                         -d "$data" "$DECRYPT_URI" \
                         -H "Authorization: Bearer $token" \
                         -H "Content-type: application/json" \
@@ -86,9 +72,28 @@ get_credentials() {
         CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
         echo $CAM_CREDENTIALS | tee ${cam_credentials_file}
     fi
+}
 
-    get_cac_token
+# Retrieves a CAC token using a python script
+get_cac_token() {
+    log "Retrieving connector token before CAC install..."
 
+    log "Downloading CAM python script from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
+    chmod +x ${cam_script}
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`./${cam_script} ${cam_credentials_file}`
+
+    # Check and exit startup script if retrieving connector token failed
+    if [ $? -ne 0 ]; then
+        log "Failed to retrieve connector token using CAM script. Exiting startup script..."
+        exit 1
+    fi
+}
+
+# Check that all required variables are present before installing the connector
+check_required_vars() {
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
         log "One of the following required variables is missing: \
@@ -98,12 +103,100 @@ get_credentials() {
     fi
 }
 
-if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
-    log "Connector already installed. Skipping startup script..."
-    exit 0
-fi
+# Ensure that the connector is not already installed
+check_connector() {
+    if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
+        log "Connector already installed. Skipping startup script..."
+        exit 0
+    fi
+}
 
+# Download CAC installer
+download_cac() {
+    curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
+}
+
+install_ldap_utils() {
+    # Wait for service account to be added. Do this last because it takes
+    # a while for new AD user to be added in a new Domain Controller.
+    # Note: using the domain controller IP instead of the domain name for
+    #       the host is more resilient.
+    log "Installing ldap_utils..."
+    RETRIES=5
+    while true; do
+        apt-get -qq update
+        apt-get -qq install ldap-utils
+        RC=$?
+        if [ $RC -eq 0 ] || [ $RETRIES -eq 0 ]; then
+            break
+        fi
+
+        log "Error installing ldap-utils. $RETRIES retries remaining..."
+        RETRIES=$((RETRIES-1))
+        sleep 5
+    done
+
+    log "Ensuring AD account is available..."
+    TIMEOUT=1200
+    until ldapwhoami \
+        -H ldap://${domain_controller_ip} \
+        -D ${ad_service_account_username}@${domain_name} \
+        -w $AD_SERVICE_ACCOUNT_PASSWORD \
+        -o nettimeout=1; do
+        if [ $TIMEOUT -le 0 ]; then
+            break
+        else
+            log "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. \
+                 Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
+        fi
+        TIMEOUT=$((TIMEOUT-10))
+        sleep 10
+    done
+}
+
+install_cac() {
+    log "Installing Cloud Access Connector..."
+    export CAM_BASE_URI=${cam_url}
+
+    if [ -z "${ssl_key}" ]; then
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --insecure \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee $INSTALL_LOG
+    else
+        gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
+        gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
+
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --ssl-key $INSTALL_DIR/${ssl_key} \
+            --ssl-cert $INSTALL_DIR/${ssl_cert} \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee $INSTALL_LOG
+    fi
+}
+
+# Script entry point starts here, sequence of actions to install CAC
+
+# Set up before CAC install
 get_credentials
+get_cac_token
+check_required_vars
+check_connector
 
 # Network tuning
 PCOIP_NETWORK_CONF_FILE="/etc/sysctl.d/01-pcoip-cac-network.conf"
@@ -123,80 +216,9 @@ if [ ! -f $PCOIP_NETWORK_CONF_FILE ]; then
     sysctl -p $PCOIP_NETWORK_CONF_FILE
 fi
 
-
-# Download CAC installer
-curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
-
-
-# Wait for service account to be added
-# do this last because it takes a while for new AD user to be added in a
-# new Domain Controller
-# Note: using the domain controller IP instead of the domain name for the
-#       host is more resilient
-echo '### Installing ldap-utils ###'
-RETRIES=5
-while true; do
-    apt-get -qq update
-    apt-get -qq install ldap-utils
-    RC=$?
-    if [ $RC -eq 0 ] || [ $RETRIES -eq 0 ]; then
-        break
-    fi
-
-    echo "Error installing ldap-utils. $RETRIES retries remaining..."
-    RETRIES=$((RETRIES-1))
-    sleep 5
-done
-
-echo '### Ensure AD account is available ###'
-TIMEOUT=1200
-until ldapwhoami \
-    -H ldap://${domain_controller_ip} \
-    -D ${ad_service_account_username}@${domain_name} \
-    -w $AD_SERVICE_ACCOUNT_PASSWORD \
-    -o nettimeout=1; do
-    if [ $TIMEOUT -le 0 ]; then
-        break
-    else
-        echo "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
-    fi
-    TIMEOUT=$((TIMEOUT-10))
-    sleep 10
-done
-
-
-echo '### Installing Cloud Access Connector ###'
-export CAM_BASE_URI=${cam_url}
-
-if [ -z "${ssl_key}" ]; then
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --insecure \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee $INSTALL_LOG
-else
-    gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
-    gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
-
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --ssl-key $INSTALL_DIR/${ssl_key} \
-        --ssl-cert $INSTALL_DIR/${ssl_cert} \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee $INSTALL_LOG
-fi
-
+# Install CAC
+download_cac
+install_ldap_utils
+install_cac
 docker service ls
+

--- a/modules/gcp/cac-igm/cac-startup.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-startup.sh.tmpl
@@ -18,45 +18,88 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$INSTALL_LOG"
 }
 
+get_cac_token() {
+    echo '### Retrieve connector token before CAC install ###'
+    log "Retrieving connector token..."
+
+    # Download the CAM python script from the bucket and run it to create a cac token
+    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
+    chmod +x ${cam_script}
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`./${cam_script} ${cam_credentials_file}`
+
+    # Check and exit startup script if retrieving connector token failed
+    if [ $? -ne 0 ]; then
+        log "Failed to retrieve connector token. Exiting startup script..."
+        exit 1
+    fi
+}
+
 get_credentials() {
+    # Download the CAM credentials JSON file from the bucket
+    gsutil cp gs://${bucket_name}/${cam_credentials_file} $INSTALL_DIR
+
+    # Download and install python, python3
+    apt-get -qq update
+    apt install -y python
+    apt install -y python3
+
     if [[ -z "${kms_cryptokey_id}" ]]; then
-        log "Not using encryption"
+        log "Not using encryption..."
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
-        CAC_TOKEN=${cac_token}
 
     else
-        log "Using encryption key ${kms_cryptokey_id}"
-
-        apt-get -qq update
-        apt install -y python
+        log "Using encryption key ${kms_cryptokey_id}..."
 
         # Gets access token attribute of response json object
-        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
+        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" \
+                                          | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
 
         # Gets data using access token and decodes it
         data=$(echo "{ \"ciphertext\": \"${pcoip_registration_code}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST \
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
         data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST \
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        CAC_TOKEN=$(echo "$b64_data" | base64 --decode)
+        # Gets decrypted CAM service account credentials and outputs to plaintext json file
+        cam_cred_encrypted=$(cat ${cam_credentials_file})
+        data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
+        b64_data=$(curl -X POST 
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
+        echo $CAM_CREDENTIALS | tee ${cam_credentials_file}
     fi
+
+    get_cac_token
 
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+        log "One of the following required variables is missing: \
+             PCOIP_REGISTRATION_CODE, AD_SERVICE_ACCOUNT_PASSWORD, CAC_TOKEN \
+             Exiting startup script..."
         exit 1
     fi
 }
 
 if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
-    log "Connector already installed. Skipping startup script."
+    log "Connector already installed. Skipping startup script..."
     exit 0
 fi
 
@@ -81,7 +124,7 @@ if [ ! -f $PCOIP_NETWORK_CONF_FILE ]; then
 fi
 
 
-# download CAC installer
+# Download CAC installer
 curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
 tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
 

--- a/modules/gcp/cac-igm/main.tf
+++ b/modules/gcp/cac-igm/main.tf
@@ -7,8 +7,11 @@
 
 locals {
   prefix = var.prefix != "" ? "${var.prefix}-" : ""
-  startup_script = "cac-startup.sh"
-  num_cacs = length(flatten([for i in var.instance_count_list: range(i)]))
+  startup_script       = "cac-startup.sh"
+  cam_script           = "cac-cam.py"
+  cam_credentials_file = "cam-cred.json"
+
+  num_cacs    = length(flatten([for i in var.instance_count_list: range(i)]))
   num_regions = length(var.gcp_zone_list)
 
   disk_image_project = regex("^projects/([-\\w]+).+$", var.disk_image)[0]
@@ -35,6 +38,22 @@ data "google_compute_image" "cac-base-img" {
   name    = local.disk_image_name
 }
 
+resource "google_storage_bucket_object" "cam-credentials-file" {
+  count = local.num_cacs == 0 ? 0 : 1
+
+  bucket = var.bucket_name
+  name   = local.cam_credentials_file
+  source = var.cam_credentials_file
+}
+
+resource "google_storage_bucket_object" "cac-cam-script" {
+  count = local.num_cacs == 0 ? 0 : 1
+
+  bucket = var.bucket_name
+  name   = local.cam_script
+  source = "${path.module}/cac-cam.py"
+}
+
 resource "google_storage_bucket_object" "cac-startup-script" {
   count = local.num_cacs == 0 ? 0 : 1
 
@@ -46,7 +65,6 @@ resource "google_storage_bucket_object" "cac-startup-script" {
       kms_cryptokey_id            = var.kms_cryptokey_id,
       cam_url                     = var.cam_url,
       cac_installer_url           = var.cac_installer_url,
-      cac_token                   = var.cac_token,
       pcoip_registration_code     = var.pcoip_registration_code,
 
       domain_controller_ip        = var.domain_controller_ip,
@@ -55,7 +73,10 @@ resource "google_storage_bucket_object" "cac-startup-script" {
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
 
-      bucket_name = var.bucket_name,
+      bucket_name          = var.bucket_name,
+      cam_credentials_file = local.cam_credentials_file,
+      cam_script           = local.cam_script,
+
       ssl_key     = "",
       ssl_cert    = "",
     }

--- a/modules/gcp/cac-igm/vars.tf
+++ b/modules/gcp/cac-igm/vars.tf
@@ -20,13 +20,13 @@ variable "cam_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_registration_code" {
-  description = "PCoIP Registration code"
+variable "cam_credentials_file" {
+  description = "Location of GCP JSON credentials file"
   type        = string
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "pcoip_registration_code" {
+  description = "PCoIP Registration code"
   type        = string
 }
 

--- a/modules/gcp/cac/cac-cam.py
+++ b/modules/gcp/cac/cac-cam.py
@@ -1,0 +1,152 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2020 Teradici Corporation
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+import os
+import requests
+import sys
+
+API_URL = None
+
+def create_connector_name():
+    """A function to create a custom connector name
+    
+    Uses metadata server to access instance data, which is used to create the connector name.
+    
+    Returns:
+        string: a string for the connector name
+    """
+
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/"
+    headers      = {"Metadata-Flavor": "Google"}
+
+    response_zone = requests.get(metadata_url + "zone", headers = headers)
+    response_name = requests.get(metadata_url + "name", headers = headers)
+
+    zone = response_zone.text.rpartition('/')[2]
+    name = response_name.text
+
+    connector_name = "{}-{}".format(zone, name)
+    
+    return connector_name
+
+
+def get_auth_token(filepath):
+    """A function to retrieve a CAM authentication token
+    
+    Uses a CAM credentials JSON file to request a CAM authentication token.
+    
+    Args:
+        filepath (str): the file location of CAM credentials JSON
+
+    Returns:
+        string: a string for the CAM authentication token
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM credentials file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    request_body = dict(username = cam_credentials.get('username'), 
+                        password = cam_credentials.get('apiKey'),
+                        tenantId = cam_credentials.get('tenantId'))
+
+    response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body = response.json()
+    auth_token    = response_body.get('data').get('token')
+
+    return auth_token
+
+
+def get_deployment_id(filepath):
+    """A function to parse the deployment ID
+    
+    Parses the deployment ID from the CAM credentials JSON
+    
+    Args:
+        filepath (str): the file location of CAM credentials JSON
+
+    Returns:
+        string: a string for the deployment ID
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM credentials file. Exiting CAM script...\n{}".format(err))
+        raise ex
+    
+    return cam_credentials.get('deploymentId')
+
+
+def get_cac_token(auth_token, deployment_id, connector_name):
+    """A function that creates a connector token
+    
+    Parses the deployment ID from the CAM credentials JSON
+    
+    Args:
+        auth_token (str): the file location of CAM credentials JSON
+        deployment_id (str): a string for the deployment ID
+        connector_name (str): a string for the connector name
+
+    Returns:
+        string: a string for the connector token
+    """
+
+    session = requests.Session()
+    session.headers.update({"Authorization": auth_token})
+
+    body = dict(deploymentId  = deployment_id, 
+                connectorName = connector_name)
+
+    response = session.post("{}/auth/tokens/connector".format(API_URL), json=body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body   = response.json()
+    connector_token = response_body.get('data').get('token')
+
+    return connector_token
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This script uses CAM credentials to create a new connector token.")
+
+    parser.add_argument("cam", help="specify the path to CAM credentials file")
+    parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
+    args = parser.parse_args()
+
+    # Allow user to override default CAM URL
+    global API_URL
+    API_URL = args.url
+
+    auth_token     = get_auth_token(args.cam)
+    deployment_id  = get_deployment_id(args.cam)
+    connector_name = create_connector_name()
+    cac_token      = get_cac_token(auth_token, deployment_id, connector_name)
+
+    return cac_token
+
+
+if __name__ == '__main__':
+    try:
+        # Print the cac_token string as the output of this script
+        print(main())
+    except:
+        # Prevent bash from interpreting any error messages
+        sys.exit(1)
+

--- a/modules/gcp/cac/cac-startup.sh.tmpl
+++ b/modules/gcp/cac/cac-startup.sh.tmpl
@@ -18,49 +18,185 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$INSTALL_LOG"
 }
 
+# Retrieves credentials required to install the connector
 get_credentials() {
+    log "Downloading CAM credentials JSON file from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_credentials_file} $INSTALL_DIR
+
+    log "Installing Python and Python3..."
+    apt-get -qq update
+    apt install -y python
+    apt install -y python3
+
     if [[ -z "${kms_cryptokey_id}" ]]; then
-        log "Not using encryption"
+        log "Not using encryption..."
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
-        CAC_TOKEN=${cac_token}
 
     else
-        log "Using encryption key ${kms_cryptokey_id}"
-
-        apt-get -qq update
-        apt install -y python
+        log "Using encryption key: ${kms_cryptokey_id}..."
 
         # Gets access token attribute of response json object
-        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
+        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" \
+                                          | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
 
         # Gets data using access token and decodes it
+        log "Decrypting PCoIP registration code..."
         data=$(echo "{ \"ciphertext\": \"${pcoip_registration_code}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST \
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
+        log "Decrypting AD service account password..."
         data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST \
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        CAC_TOKEN=$(echo "$b64_data" | base64 --decode)
+        log "Decrypting CAM service account credentials..."
+        # Gets decrypted CAM service account credentials and outputs to plaintext json file
+        cam_cred_encrypted=$(cat ${cam_credentials_file})
+        data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
+        b64_data=$(curl -X POST \
+                        -d "$data" "$DECRYPT_URI" \
+                        -H "Authorization: Bearer $token" \
+                        -H "Content-type: application/json" \
+                        | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
+        echo $CAM_CREDENTIALS | tee ${cam_credentials_file}
     fi
+}
 
-    # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+# Retrieves a CAC token using a python script
+get_cac_token() {
+    log "Retrieving connector token before CAC install..."
+
+    log "Downloading CAM python script from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
+    chmod +x ${cam_script}
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`./${cam_script} ${cam_credentials_file}`
+
+    # Check and exit startup script if retrieving connector token failed
+    if [ $? -ne 0 ]; then
+        log "Failed to retrieve connector token using CAM script. Exiting startup script..."
         exit 1
     fi
 }
 
-if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
-    log "Connector already installed. Skipping startup script."
-    exit 0
-fi
+# Check that all required variables are present before installing the connector
+check_required_vars() {
+    # Exit if any of the required variables are missing
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+        log "One of the following required variables is missing: \
+             PCOIP_REGISTRATION_CODE, AD_SERVICE_ACCOUNT_PASSWORD, CAC_TOKEN \
+             Exiting startup script..."
+        exit 1
+    fi
+}
 
+# Ensure that the connector is not already installed
+check_connector() {
+    if [[ -f "$INSTALL_DIR/cloud-access-connector" ]]; then
+        log "Connector already installed. Skipping startup script..."
+        exit 0
+    fi
+}
+
+# Download CAC installer
+download_cac() {
+    curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
+    tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
+}
+
+install_ldap_utils() {
+    # Wait for service account to be added. Do this last because it takes
+    # a while for new AD user to be added in a new Domain Controller.
+    # Note: using the domain controller IP instead of the domain name for
+    #       the host is more resilient.
+    log "Installing ldap_utils..."
+    RETRIES=5
+    while true; do
+        apt-get -qq update
+        apt-get -qq install ldap-utils
+        RC=$?
+        if [ $RC -eq 0 ] || [ $RETRIES -eq 0 ]; then
+            break
+        fi
+
+        log "Error installing ldap-utils. $RETRIES retries remaining..."
+        RETRIES=$((RETRIES-1))
+        sleep 5
+    done
+
+    log "Ensuring AD account is available..."
+    TIMEOUT=1200
+    until ldapwhoami \
+        -H ldap://${domain_controller_ip} \
+        -D ${ad_service_account_username}@${domain_name} \
+        -w $AD_SERVICE_ACCOUNT_PASSWORD \
+        -o nettimeout=1; do
+        if [ $TIMEOUT -le 0 ]; then
+            break
+        else
+            log "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. \
+                 Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
+        fi
+        TIMEOUT=$((TIMEOUT-10))
+        sleep 10
+    done
+}
+
+install_cac() {
+    log "Installing Cloud Access Connector..."
+    export CAM_BASE_URI=${cam_url}
+
+    if [ -z "${ssl_key}" ]; then
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --insecure \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee $INSTALL_LOG
+    else
+        gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
+        gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
+
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --ssl-key $INSTALL_DIR/${ssl_key} \
+            --ssl-cert $INSTALL_DIR/${ssl_cert} \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee $INSTALL_LOG
+    fi
+}
+
+# Script entry point starts here, sequence of actions to install CAC
+
+# Set up before CAC install
 get_credentials
+get_cac_token
+check_required_vars
+check_connector
 
 # Network tuning
 PCOIP_NETWORK_CONF_FILE="/etc/sysctl.d/01-pcoip-cac-network.conf"
@@ -80,80 +216,9 @@ if [ ! -f $PCOIP_NETWORK_CONF_FILE ]; then
     sysctl -p $PCOIP_NETWORK_CONF_FILE
 fi
 
-
-# download CAC installer
-curl -L ${cac_installer_url} -o $INSTALL_DIR/cloud-access-connector.tar.gz
-tar xzvf $INSTALL_DIR/cloud-access-connector.tar.gz
-
-
-# Wait for service account to be added
-# do this last because it takes a while for new AD user to be added in a
-# new Domain Controller
-# Note: using the domain controller IP instead of the domain name for the
-#       host is more resilient
-echo '### Installing ldap-utils ###'
-RETRIES=5
-while true; do
-    apt-get -qq update
-    apt-get -qq install ldap-utils
-    RC=$?
-    if [ $RC -eq 0 ] || [ $RETRIES -eq 0 ]; then
-        break
-    fi
-
-    echo "Error installing ldap-utils. $RETRIES retries remaining..."
-    RETRIES=$((RETRIES-1))
-    sleep 5
-done
-
-echo '### Ensure AD account is available ###'
-TIMEOUT=1200
-until ldapwhoami \
-    -H ldap://${domain_controller_ip} \
-    -D ${ad_service_account_username}@${domain_name} \
-    -w $AD_SERVICE_ACCOUNT_PASSWORD \
-    -o nettimeout=1; do
-    if [ $TIMEOUT -le 0 ]; then
-        break
-    else
-        echo "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
-    fi
-    TIMEOUT=$((TIMEOUT-10))
-    sleep 10
-done
-
-
-echo '### Installing Cloud Access Connector ###'
-export CAM_BASE_URI=${cam_url}
-
-if [ -z "${ssl_key}" ]; then
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --insecure \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee $INSTALL_LOG
-else
-    gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
-    gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
-
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --ssl-key $INSTALL_DIR/${ssl_key} \
-        --ssl-cert $INSTALL_DIR/${ssl_cert} \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee $INSTALL_LOG
-fi
-
+# Install CAC
+download_cac
+install_ldap_utils
+install_cac
 docker service ls
+

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -20,13 +20,13 @@ variable "cam_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_registration_code" {
-  description = "PCoIP Registration code"
+variable "cam_credentials_file" {
+  description = "Location of GCP JSON credentials file"
   type        = string
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "pcoip_registration_code" {
+  description = "PCoIP Registration code"
   type        = string
 }
 


### PR DESCRIPTION
- This pull request addresses all comments in the previous pull request to use CAM service account credentials instead of CAC token.
- Single connector and multi-region deployments have been changed over to use CAM service account and also tested.
- Both plaintext and encrypted secrets deployments are tested as well. Encryption was done using gcp-kms-secrets.py from the gcp-kms-script branch.