### PR TITLE
AWS: Provide option to use AWS KMS encryption

### DIFF
--- a/deployments/aws/single-connector/main.tf
+++ b/deployments/aws/single-connector/main.tf
@@ -30,6 +30,7 @@ module "dc" {
 
   prefix = var.prefix
   
+  customer_master_key_id   = var.customer_master_key_id
   domain_name              = var.domain_name
   admin_password           = var.dc_admin_password
   safe_mode_admin_password = var.safe_mode_admin_password
@@ -64,6 +65,8 @@ module "cac" {
 
   prefix = var.prefix
 
+  aws_region              = var.aws_region
+  customer_master_key_id  = var.customer_master_key_id
   cam_url                 = var.cam_url
   pcoip_registration_code = var.pcoip_registration_code
   cac_token               = var.cac_token
@@ -100,6 +103,8 @@ module "win-gfx" {
 
   prefix = var.prefix
 
+  customer_master_key_id = var.customer_master_key_id
+
   pcoip_registration_code = var.pcoip_registration_code
 
   domain_name              = var.domain_name
@@ -132,6 +137,8 @@ module "win-std" {
 
   prefix = var.prefix
 
+  customer_master_key_id = var.customer_master_key_id
+
   pcoip_registration_code = var.pcoip_registration_code
 
   domain_name              = var.domain_name
@@ -163,6 +170,8 @@ module "centos-gfx" {
   instance_count = var.centos_gfx_instance_count
 
   prefix = var.prefix
+
+  customer_master_key_id = var.customer_master_key_id
 
   pcoip_registration_code = var.pcoip_registration_code
 
@@ -197,6 +206,8 @@ module "centos-std" {
   instance_count = var.centos_std_instance_count
 
   prefix = var.prefix
+
+  customer_master_key_id = var.customer_master_key_id
 
   pcoip_registration_code = var.pcoip_registration_code
 

--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -55,6 +55,26 @@ centos_std_instance_count = 0
 ###############
 #   Secrets   #
 ###############
+# The secrets below may be supplied in 2 formats:
+#   1. plain text
+#   2. AWS KMS encrypted, base64 encoded
+#
+# For option 1, leave "customer_master_key_id" commented out and enter the
+# plaintext passwords as strings in the variables below. Note that plaintext
+# passwords may show in Terraform logs and .tfstate files, appear unencrypted
+# in the storage bucket holding the startup scripts, as well as in the startup
+# scripts once downloaded by the VMs.
+#
+# For option 2, a user encrypts the secrets independent of these Terraform
+# scripts. Once the secrets are encrypted with an AWS KMS customer managed CMK,
+# set the "customer_master_key_id" to key ID used to encrypt the secrets, and
+# enter the base64-encoded ciphertext as strings in the variables below. The
+# AWS IAM account corresponding to the "aws_credentials_file" above must have
+# admin permissions to manage the CMK specified.
+
+# (Optional) If using encryption, enter the CMK ID, in the form of a UUID, e.g.
+# "123e4567-e89b-12d3-a456-426655440000". Otherwise, comment out.
+customer_master_key_id = "<key-id>"
 
 # Note Windows password complexity requirements:
 # 1. Must not contain user's account name or display name

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -264,3 +264,8 @@ variable "centos_std_ami_name" {
   description = "Name of the CentOS AMI to create workstation from"
   default     = "CentOS Linux 7 x86_64 HVM EBS ENA 1901*"
 }
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
+}

--- a/modules/aws/cac/cac-startup.sh.tmpl
+++ b/modules/aws/cac/cac-startup.sh.tmpl
@@ -15,11 +15,22 @@ log() {
 }
 
 get_credentials() {
-    log "Not using encryption"
+    if [[ -z "${customer_master_key_id}" ]]; then
+        log "Not using encryption"
 
-    PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-    SERVICE_ACCOUNT_PASSWORD=${service_account_password}
-    CAC_TOKEN=${cac_token}
+        PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
+        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        CAC_TOKEN=${cac_token}
+
+    else
+        log "Using encryption key ${customer_master_key_id}"
+
+        apt install -y awscli
+
+        PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
+        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+        CAC_TOKEN=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${cac_token}" | base64 -d) --output text --query Plaintext | base64 -d)
+    fi
 
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then

--- a/modules/aws/cac/vars.tf
+++ b/modules/aws/cac/vars.tf
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+variable "aws_region" {
+  description = "AWS region"
+  default     = "us-west-1"
+}
+
 variable "prefix" {
   description = "Prefix to add to name of new resources"
   default     = ""
@@ -103,4 +108,9 @@ variable "admin_ssh_key_name" {
 variable "cac_installer_url" {
   description = "Location of the Cloud Access Connector installer"
   default     = "https://teradici.bintray.com/cloud-access-connector/cloud-access-connector-0.1.1.tar.gz"
+}
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
 }

--- a/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -16,10 +16,18 @@ log() {
 }
 
 get_credentials() {
-    log "Not using encryption"
+    if [[ -z "${customer_master_key_id}" ]]; then
+        log "Not using encryption"
 
-    PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-    SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
+        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+
+    else
+        log "Using encryption key ${customer_master_key_id}"
+
+        PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
+        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+    fi
 
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
@@ -286,16 +294,14 @@ fi
 
 log "$(date)"
 
-get_credentials
-
 if [[ $RE_ENTER -eq 0 ]]
 then
     # EPEL needed for GraphicsMagick-c++, required by PCoIP Agent
     yum -y install epel-release
-
     yum -y update
-
     yum install -y wget awscli jq
+
+    get_credentials
 
     update_hostname
 
@@ -312,6 +318,8 @@ then
 
     exit_and_restart
 else
+    get_credentials
+
     install_kernel_header
 
     install_gpu_driver

--- a/modules/aws/centos-gfx/main.tf
+++ b/modules/aws/centos-gfx/main.tf
@@ -23,6 +23,8 @@ resource "aws_s3_bucket_object" "centos-gfx-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
+      aws_region               = var.aws_region, 
+      customer_master_key_id   = var.customer_master_key_id,
       pcoip_registration_code  = var.pcoip_registration_code,
       domain_controller_ip     = var.domain_controller_ip,
       domain_name              = var.domain_name,
@@ -64,6 +66,12 @@ data "aws_iam_policy_document" "instance-assume-role-policy-doc" {
   }
 }
 
+data "aws_kms_key" "encryption-key" {
+  count = var.customer_master_key_id == "" ? 0 : 1
+
+  key_id = var.customer_master_key_id
+}
+
 resource "aws_iam_role" "centos-gfx-role" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
@@ -82,6 +90,16 @@ data "aws_iam_policy_document" "centos-gfx-policy-doc" {
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${var.bucket_name}/${local.startup_script}"]
     effect    = "Allow"
+  }
+
+  dynamic statement {
+    for_each = data.aws_kms_key.encryption-key
+    iterator = i
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = [i.value.arn]
+      effect    = "Allow"
+    }
   }
 }
 

--- a/modules/aws/centos-gfx/vars.tf
+++ b/modules/aws/centos-gfx/vars.tf
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+variable "aws_region" {
+  description = "AWS region"
+  default     = "us-west-1"
+}
+
 variable "prefix" {
   description = "Prefix to add to name of new resources"
   default     = ""
@@ -99,4 +104,9 @@ variable "nvidia_driver_url" {
 variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []
+}
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
 }

--- a/modules/aws/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/aws/centos-std/centos-std-startup.sh.tmpl
@@ -16,10 +16,18 @@ log() {
 }
 
 get_credentials() {
-    log "Not using encryption"
+    if [[ -z "${customer_master_key_id}" ]]; then
+        log "Not using encryption"
 
-    PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-    SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
+        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+
+    else
+        log "Using encryption key ${customer_master_key_id}"
+
+        PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
+        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+    fi
 
     # Exit if any of the required variables are missing
     if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
@@ -188,14 +196,12 @@ fi
 
 log "$(date)"
 
-get_credentials
-
 # EPEL needed for GraphicsMagick-c++, required by PCoIP Agent
 yum -y install epel-release
-
 yum -y update
-
 yum install -y wget awscli jq
+
+get_credentials
 
 update_hostname
 

--- a/modules/aws/centos-std/vars.tf
+++ b/modules/aws/centos-std/vars.tf
@@ -5,6 +5,11 @@
  * LICENSE file in the root directory of this source tree.
  */
 
+variable "aws_region" {
+  description = "AWS region"
+  default     = "us-west-1"
+}
+
 variable "prefix" {
   description = "Prefix to add to name of new resources"
   default     = ""
@@ -94,4 +99,9 @@ variable "admin_ssh_key_name" {
 variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []
+}
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
 }

--- a/modules/aws/dc/dc-startup.ps1.tmpl
+++ b/modules/aws/dc/dc-startup.ps1.tmpl
@@ -8,9 +8,28 @@ $LOG_FILE = "C:\Teradici\provisioning.log"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("admin_password", "${admin_password}")
 
+function Decrypt-Credentials {
+    try {
+        $ByteAry = [System.Convert]::FromBase64String("${admin_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."admin_password" = $StreamRead.ReadToEnd()
+    }
+    catch {
+        "Error decrypting credentials: $_"
+        return $false
+    }
+}
+
 Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
 
-"Not using encryption"
+if ([string]::IsNullOrWhiteSpace("${customer_master_key_id}")) {
+    "Not using encryption"
+} else {
+    "Using encryption key ${customer_master_key_id}"
+    Decrypt-Credentials
+}
 
 "Setting Administrator password ..."
 net user Administrator $DATA."admin_password" /active:yes

--- a/modules/aws/dc/main.tf
+++ b/modules/aws/dc/main.tf
@@ -16,6 +16,16 @@ locals {
   domain_users_list_file     = "C:/Temp/domain_users_list.csv"
   new_domain_users           = var.domain_users_list == "" ? 0 : 1
   startup_script             = "dc-startup.ps1"
+  admin_password = var.customer_master_key_id == "" ? var.admin_password : data.aws_kms_secrets.decrypted_secrets[0].plaintext["admin_password"]
+}
+
+data "aws_kms_secrets" "decrypted_secrets" {
+  count = var.customer_master_key_id == "" ? 0 : 1
+
+  secret {
+    name    = "admin_password"
+    payload = var.admin_password
+  }
 }
 
 resource "aws_s3_bucket_object" "dc-startup-script" {
@@ -24,8 +34,9 @@ resource "aws_s3_bucket_object" "dc-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      admin_password = var.admin_password,
-      hostname       = local.host_name,
+      customer_master_key_id = var.customer_master_key_id
+      admin_password         = var.admin_password
+      hostname               = local.host_name
     }
   )
 }
@@ -43,6 +54,7 @@ data "template_file" "setup-script" {
   template = file("${path.module}/setup.ps1.tpl")
 
   vars = {
+    customer_master_key_id   = var.customer_master_key_id
     domain_name              = var.domain_name
     safe_mode_admin_password = var.safe_mode_admin_password
   }
@@ -52,10 +64,11 @@ data "template_file" "new-domain-admin-user-script" {
   template = file("${path.module}/new_domain_admin_user.ps1.tpl")
 
   vars = {
-    host_name        = local.host_name
-    domain_name      = var.domain_name
-    account_name     = var.service_account_username
-    account_password = var.service_account_password
+    customer_master_key_id = var.customer_master_key_id
+    host_name              = local.host_name
+    domain_name            = var.domain_name
+    account_name           = var.service_account_username
+    account_password       = var.service_account_password
   }
 }
 
@@ -95,11 +108,27 @@ resource "aws_iam_role" "dc-role" {
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
+data "aws_kms_key" "encryption-key" {
+  count = var.customer_master_key_id == "" ? 0 : 1
+
+  key_id = var.customer_master_key_id
+}
+
 data "aws_iam_policy_document" "dc-policy-doc" {
   statement {
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${var.bucket_name}/${local.startup_script}"]
     effect    = "Allow"
+  }
+
+  dynamic statement {
+    for_each = data.aws_kms_key.encryption-key
+    iterator = i
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = [i.value.arn]
+      effect    = "Allow"
+    }
   }
 }
 
@@ -148,7 +177,7 @@ resource "null_resource" "upload-scripts" {
   connection {
     type     = "winrm"
     user     = "Administrator"
-    password = var.admin_password
+    password = local.admin_password
     host     = aws_instance.dc.public_ip
     port     = 5986
     https    = true
@@ -182,7 +211,7 @@ resource "null_resource" "upload-domain-users-list" {
   connection {
     type     = "winrm"
     user     = "Administrator"
-    password = var.admin_password
+    password = local.admin_password
     host     = aws_instance.dc.public_ip
     port     = 5986
     https    = true
@@ -204,7 +233,7 @@ resource "null_resource" "run-setup-script" {
   connection {
     type     = "winrm"
     user     = "Administrator"
-    password = var.admin_password
+    password = local.admin_password
     host     = aws_instance.dc.public_ip
     port     = 5986
     https    = true
@@ -242,7 +271,7 @@ resource "null_resource" "new-domain-admin-user" {
   connection {
     type     = "winrm"
     user     = "Administrator"
-    password = var.admin_password
+    password = local.admin_password
     host     = aws_instance.dc.public_ip
     port     = 5986
     https    = true
@@ -273,7 +302,7 @@ resource "null_resource" "new-domain-user" {
   connection {
     type     = "winrm"
     user     = "Administrator"
-    password = var.admin_password
+    password = local.admin_password
     host     = aws_instance.dc.public_ip
     port     = 5986
     https    = true

--- a/modules/aws/dc/setup.ps1.tpl
+++ b/modules/aws/dc/setup.ps1.tpl
@@ -10,9 +10,28 @@ $LOG_FILE = "C:\Teradici\provisioning.log"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("safe_mode_admin_password", "${safe_mode_admin_password}")
 
+function Decrypt-Credentials {
+    try {
+        $ByteAry = [System.Convert]::FromBase64String("${safe_mode_admin_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream 
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."safe_mode_admin_password" = $StreamRead.ReadToEnd()
+    }
+    catch {
+        "Error decrypting credentials: $_"
+        return $false
+    }
+}
+
 Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
 
-"Not using encryption"
+if ([string]::IsNullOrWhiteSpace("${customer_master_key_id}")) {
+    "Not using encryption"
+} else {
+    "Using encryption key ${customer_master_key_id}"
+    Decrypt-Credentials
+}
 
 $DomainName = "${domain_name}"
 $DomainMode = "7"

--- a/modules/aws/dc/vars.tf
+++ b/modules/aws/dc/vars.tf
@@ -79,3 +79,8 @@ variable "ami_name" {
   description = "Name of the Windows AMI to create the Domain Controller from"
   default     = "Windows_Server-2016-English-Full-Base-*"
 }
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
+}

--- a/modules/aws/win-gfx/vars.tf
+++ b/modules/aws/win-gfx/vars.tf
@@ -101,3 +101,8 @@ variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []
 }
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
+}

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -12,6 +12,32 @@ $DATA.Add("service_account_password", "${service_account_password}")
 
 $global:restart = $false
 
+function Decrypt-Credentials {
+    try {
+        $ByteAry = [System.Convert]::FromBase64String("${pcoip_registration_code}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."pcoip_registration_code" = $StreamRead.ReadToEnd()
+    
+        $ByteAry = [System.Convert]::FromBase64String("${admin_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."admin_password" = $StreamRead.ReadToEnd()
+    
+        $ByteAry = [System.Convert]::FromBase64String("${service_account_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."service_account_password" = $StreamRead.ReadToEnd()
+    }
+    catch {
+        "Error decrypting credentials: $_"
+        return $false
+    }
+}
+
 # Retry function, defaults to trying for 5 minutes with 10 seconds intervals
 function Retry([scriptblock]$Action, $Interval = 10, $Attempts = 30) {
   $Current_Attempt = 0
@@ -231,7 +257,12 @@ if ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administ
     "Not running as Administrator"
 }
 
-"This script is not using encryption for secrets."
+if ([string]::IsNullOrWhiteSpace("${customer_master_key_id}")) {
+    "This script is not using encryption for secrets."
+} else {
+    "Using encryption key ${customer_master_key_id} for secrets."
+    Decrypt-Credentials
+}
 
 net user Administrator $DATA."admin_password" /active:yes
 

--- a/modules/aws/win-std/main.tf
+++ b/modules/aws/win-std/main.tf
@@ -24,6 +24,7 @@ resource "aws_s3_bucket_object" "win-std-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
+      customer_master_key_id   = var.customer_master_key_id,
       pcoip_agent_location     = var.pcoip_agent_location,
       pcoip_agent_filename     = var.pcoip_agent_filename,
       pcoip_registration_code  = var.pcoip_registration_code,
@@ -74,6 +75,12 @@ resource "aws_iam_role" "win-std-role" {
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
+data "aws_kms_key" "encryption-key" {
+  count = var.customer_master_key_id == "" ? 0 : 1
+
+  key_id = var.customer_master_key_id
+}
+
 data "aws_iam_policy_document" "win-std-policy-doc" {
   statement {
     actions   = ["ec2:DescribeTags"]
@@ -85,6 +92,16 @@ data "aws_iam_policy_document" "win-std-policy-doc" {
     actions   = ["s3:GetObject"]
     resources = ["arn:aws:s3:::${var.bucket_name}/${local.startup_script}"]
     effect    = "Allow"
+  }
+
+  dynamic statement {
+    for_each = data.aws_kms_key.encryption-key
+    iterator = i
+    content {
+      actions   = ["kms:Decrypt"]
+      resources = [i.value.arn]
+      effect    = "Allow"
+    }
   }
 }
 

--- a/modules/aws/win-std/vars.tf
+++ b/modules/aws/win-std/vars.tf
@@ -99,3 +99,8 @@ variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []
 }
+
+variable "customer_master_key_id" {
+  description = "The ID of the AWS KMS Customer Master Key used to decrypt secrets"
+  default     = ""
+}

--- a/modules/aws/win-std/win-std-startup.ps1.tmpl
+++ b/modules/aws/win-std/win-std-startup.ps1.tmpl
@@ -12,6 +12,32 @@ $DATA.Add("service_account_password", "${service_account_password}")
 
 $global:restart = $false
 
+function Decrypt-Credentials {
+    try {
+        $ByteAry = [System.Convert]::FromBase64String("${pcoip_registration_code}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."pcoip_registration_code" = $StreamRead.ReadToEnd()
+    
+        $ByteAry = [System.Convert]::FromBase64String("${admin_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."admin_password" = $StreamRead.ReadToEnd()
+    
+        $ByteAry = [System.Convert]::FromBase64String("${service_account_password}")
+        $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
+        $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
+        $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
+        $DATA."service_account_password" = $StreamRead.ReadToEnd()
+    }
+    catch {
+        "Error decrypting credentials: $_"
+        return $false
+    }
+}
+
 # Retry function, defaults to trying for 5 minutes with 10 seconds intervals
 function Retry([scriptblock]$Action, $Interval = 10, $Attempts = 30) {
   $Current_Attempt = 0
@@ -230,7 +256,12 @@ if ($currentPrincipal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administ
     "Not running as Administrator"
 }
 
-"This script is not using encryption for secrets."
+if ([string]::IsNullOrWhiteSpace("${customer_master_key_id}")) {
+    "This script is not using encryption for secrets."
+} else {
+    "Using encryption key ${customer_master_key_id} for secrets."
+    Decrypt-Credentials
+}
 
 net user Administrator $DATA."admin_password" /active:yes
 


### PR DESCRIPTION
Secrets used in the deployment can be optionally encrypted before being
entered into the .tfvars file.

Signed-off-by: Sherman Yin <syin@teradici.com>