### PR TITLE
Remove port 80 from firewall rule

### DIFF
--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -75,7 +75,6 @@ module "cac-igm" {
   network_tags  = [
     "${google_compute_firewall.allow-ssh.name}",
     "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-http.name}",
     "${google_compute_firewall.allow-https.name}",
     "${google_compute_firewall.allow-pcoip.name}",
   ]

--- a/deployments/gcp/multi-region/networking.tf
+++ b/deployments/gcp/multi-region/networking.tf
@@ -68,19 +68,6 @@ resource "google_compute_firewall" "allow-ssh" {
   source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
 }
 
-resource "google_compute_firewall" "allow-http" {
-  name    = "${local.prefix}fw-allow-http"
-  network = google_compute_network.vpc.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["80"]
-  }
-
-  target_tags   = ["${local.prefix}fw-allow-http"]
-  source_ranges = ["0.0.0.0/0"]
-}
-
 resource "google_compute_firewall" "allow-https" {
   name    = "${local.prefix}fw-allow-https"
   network = google_compute_network.vpc.self_link

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -74,7 +74,6 @@ module "cac" {
   network_tags = [
     "${google_compute_firewall.allow-ssh.name}",
     "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-http.name}",
     "${google_compute_firewall.allow-https.name}",
     "${google_compute_firewall.allow-pcoip.name}",
   ]

--- a/deployments/gcp/single-connector/networking.tf
+++ b/deployments/gcp/single-connector/networking.tf
@@ -68,19 +68,6 @@ resource "google_compute_firewall" "allow-ssh" {
   source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
 }
 
-resource "google_compute_firewall" "allow-http" {
-  name    = "${local.prefix}fw-allow-http"
-  network = google_compute_network.vpc.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["80"]
-  }
-
-  target_tags   = ["${local.prefix}fw-allow-http"]
-  source_ranges = ["0.0.0.0/0"]
-}
-
 resource "google_compute_firewall" "allow-https" {
   name    = "${local.prefix}fw-allow-https"
   network = google_compute_network.vpc.self_link


### PR DESCRIPTION
Port 80 of CAC was opened to the world and should not be needed.
The firewall rule for TCP port 80 is now removed for both multi-region
and single connector deployment.

Signed-off-by: Edwin Pau <epau@teradici.com>