### PR TITLE
Change active directory variable names for AWS

### DIFF
--- a/deployments/aws/single-connector/main.tf
+++ b/deployments/aws/single-connector/main.tf
@@ -30,13 +30,13 @@ module "dc" {
 
   prefix = var.prefix
   
-  customer_master_key_id   = var.customer_master_key_id
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  safe_mode_admin_password = var.safe_mode_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
-  domain_users_list        = var.domain_users_list
+  customer_master_key_id      = var.customer_master_key_id
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  safe_mode_admin_password    = var.safe_mode_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
+  domain_users_list           = var.domain_users_list
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.dc-subnet.id
@@ -71,10 +71,10 @@ module "cac" {
   pcoip_registration_code = var.pcoip_registration_code
   cac_token               = var.cac_token
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.cac-subnet.id
@@ -107,10 +107,10 @@ module "win-gfx" {
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.ws-subnet.id
@@ -141,10 +141,10 @@ module "win-std" {
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  admin_password           = var.dc_admin_password
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  admin_password              = var.dc_admin_password
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.ws-subnet.id
@@ -175,10 +175,10 @@ module "centos-gfx" {
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.ws-subnet.id
@@ -211,10 +211,10 @@ module "centos-std" {
 
   pcoip_registration_code = var.pcoip_registration_code
 
-  domain_name              = var.domain_name
-  domain_controller_ip     = module.dc.internal-ip
-  service_account_username = var.service_account_username
-  service_account_password = var.service_account_password
+  domain_name                 = var.domain_name
+  domain_controller_ip        = module.dc.internal-ip
+  ad_service_account_username = var.ad_service_account_username
+  ad_service_account_password = var.ad_service_account_password
 
   bucket_name        = aws_s3_bucket.scripts.id
   subnet             = aws_subnet.ws-subnet.id

--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -86,8 +86,8 @@ customer_master_key_id = "<key-id>"
 #    3. unicode characters
 # See: https://docs.microsoft.com/en-us/windows/security/threat-protection/security-policy-settings/password-must-meet-complexity-requirements
 
-dc_admin_password        = "SecuRe_pwd1"
-safe_mode_admin_password = "SecuRe_pwd2"
-service_account_password = "SecuRe_pwd3"
-pcoip_registration_code  = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                = "token from Cloud Access Manager for the connector"
+dc_admin_password           = "SecuRe_pwd1"
+safe_mode_admin_password    = "SecuRe_pwd2"
+ad_service_account_password = "SecuRe_pwd3"
+pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
+cac_token                   = "token from Cloud Access Manager for the connector"

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -80,12 +80,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account name to be created"
   default     = "cam_admin"
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/modules/aws/cac/cac-startup.sh.tmpl
+++ b/modules/aws/cac/cac-startup.sh.tmpl
@@ -19,7 +19,7 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
         CAC_TOKEN=${cac_token}
 
     else
@@ -28,15 +28,15 @@ get_credentials() {
         apt install -y awscli
 
         PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
-        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${ad_service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
         CAC_TOKEN=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${cac_token}" | base64 -d) --output text --query Plaintext | base64 -d)
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" || -z "$CAC_TOKEN" ]]; then
         log "Missing required parameters:"
         log "PCoIP Registration Code = $PCOIP_REGISTRATION_CODE"
-        log "Service Account Password = $SERVICE_ACCOUNT_PASSWORD"
+        log "Active Directory Service Account Password = $AD_SERVICE_ACCOUNT_PASSWORD"
         log "CAC Token = $CAC_TOKEN"
         exit 1
     fi
@@ -97,13 +97,13 @@ echo '### Ensure AD account is available ###'
 TIMEOUT=1200
 until ldapwhoami \
     -H ldap://${domain_controller_ip} \
-    -D ${service_account_username}@${domain_name} \
-    -w $SERVICE_ACCOUNT_PASSWORD \
+    -D ${ad_service_account_username}@${domain_name} \
+    -w $AD_SERVICE_ACCOUNT_PASSWORD \
     -o nettimeout=1; do
     if [ $TIMEOUT -le 0 ]; then
         break
     else
-        echo "Waiting for AD account ${service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
+        echo "Waiting for AD account ${ad_service_account_username}@${domain_name} to become available. Retrying in 10 seconds... (Timeout in $TIMEOUT seconds)"
     fi
     TIMEOUT=$((TIMEOUT-10))
     sleep 10
@@ -117,8 +117,8 @@ $INSTALL_DIR/cloud-access-connector install \
     -t $CAC_TOKEN \
     --accept-policies \
     --insecure \
-    --sa-user ${service_account_username} \
-    --sa-password "$SERVICE_ACCOUNT_PASSWORD" \
+    --sa-user ${ad_service_account_username} \
+    --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
     --domain ${domain_name} \
     --domain-group "${domain_group}" \
     --reg-code $PCOIP_REGISTRATION_CODE \

--- a/modules/aws/cac/main.tf
+++ b/modules/aws/cac/main.tf
@@ -25,11 +25,11 @@ resource "aws_s3_bucket_object" "cac-startup-script" {
       cac_token                = var.cac_token,
       pcoip_registration_code  = var.pcoip_registration_code,
 
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      domain_group             = var.domain_group,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      domain_group                = var.domain_group,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/aws/cac/vars.tf
+++ b/modules/aws/cac/vars.tf
@@ -45,12 +45,12 @@ variable "domain_group" {
   default     = "Domain Admins"
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -20,20 +20,20 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
 
     else
         log "Using encryption key ${customer_master_key_id}"
 
         PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
-        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${ad_service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" ]]; then
         log "Missing required parameters:"
         log "PCoIP Registration Code = $PCOIP_REGISTRATION_CODE"
-        log "Service Account Password = $SERVICE_ACCOUNT_PASSWORD"
+        log "Service Account Password = $AD_SERVICE_ACCOUNT_PASSWORD"
         exit 1
     fi
 }
@@ -195,7 +195,7 @@ join_domain()
     if [[ ! -f "$dns_record_file" ]]
     then
         log "--> DOMAIN NAME: ${domain_name}"
-        log "--> USERNAME: ${service_account_username}"
+        log "--> USERNAME: ${ad_service_account_username}"
         log "--> DOMAIN CONTROLLER: ${domain_controller_ip}"
 
         # default hostname has the form ip-10-0-0-1.us-west-1.compute.internal,
@@ -204,10 +204,10 @@ join_domain()
 
         # Wait for AD service account to be set up
         yum -y install openldap-clients
-        log "--> Wait for AD account ${service_account_username}@${domain_name} to be available"
-        until ldapwhoami -H ldap://${domain_controller_ip} -D ${service_account_username}@${domain_name} -w "$SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
+        log "--> Wait for AD account ${ad_service_account_username}@${domain_name} to be available"
+        until ldapwhoami -H ldap://${domain_controller_ip} -D ${ad_service_account_username}@${domain_name} -w "$AD_SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
         do
-            log "${service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
+            log "${ad_service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
             sleep 10
         done
 
@@ -232,9 +232,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]
@@ -255,7 +255,7 @@ join_domain()
         log "--> Registering with DNS"
         DOMAIN_UPPER=$(echo "${domain_name}" | tr '[:lower:]' '[:upper:]')
         IP_ADDRESS=$(hostname -I | grep -Eo '10.([0-9]*\.){2}[0-9]*')
-        echo "$SERVICE_ACCOUNT_PASSWORD" | kinit "${service_account_username}"@"$DOMAIN_UPPER"
+        echo "$AD_SERVICE_ACCOUNT_PASSWORD" | kinit "${ad_service_account_username}"@"$DOMAIN_UPPER"
         touch "$dns_record_file"
         echo "server ${domain_controller_ip}" > "$dns_record_file"
         echo "update add $VM_NAME.${domain_name} 600 a $IP_ADDRESS" >> "$dns_record_file"

--- a/modules/aws/centos-gfx/main.tf
+++ b/modules/aws/centos-gfx/main.tf
@@ -23,14 +23,14 @@ resource "aws_s3_bucket_object" "centos-gfx-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      aws_region               = var.aws_region, 
-      customer_master_key_id   = var.customer_master_key_id,
-      pcoip_registration_code  = var.pcoip_registration_code,
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
-      nvidia_driver_url        = var.nvidia_driver_url,
+      aws_region                  = var.aws_region, 
+      customer_master_key_id      = var.customer_master_key_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
+      nvidia_driver_url           = var.nvidia_driver_url,
     }
   )
 }

--- a/modules/aws/centos-gfx/vars.tf
+++ b/modules/aws/centos-gfx/vars.tf
@@ -35,12 +35,12 @@ variable "domain_controller_ip" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/aws/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/aws/centos-std/centos-std-startup.sh.tmpl
@@ -20,20 +20,20 @@ get_credentials() {
         log "Not using encryption"
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
-        SERVICE_ACCOUNT_PASSWORD=${service_account_password}
+        AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
 
     else
         log "Using encryption key ${customer_master_key_id}"
 
         PCOIP_REGISTRATION_CODE=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${pcoip_registration_code}" | base64 -d) --output text --query Plaintext | base64 -d)
-        SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
+        AD_SERVICE_ACCOUNT_PASSWORD=$(aws kms decrypt --region ${aws_region} --ciphertext-blob fileb://<(echo "${ad_service_account_password}" | base64 -d) --output text --query Plaintext | base64 -d)
     fi
 
     # Exit if any of the required variables are missing
-    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$SERVICE_ACCOUNT_PASSWORD" ]]; then
+    if [[ -z "$PCOIP_REGISTRATION_CODE" || -z "$AD_SERVICE_ACCOUNT_PASSWORD" ]]; then
         log "Missing required parameters:"
         log "PCoIP Registration Code = $PCOIP_REGISTRATION_CODE"
-        log "Service Account Password = $SERVICE_ACCOUNT_PASSWORD"
+        log "Active Directory Service Account Password = $AD_SERVICE_ACCOUNT_PASSWORD"
         exit 1
     fi
 }
@@ -101,7 +101,7 @@ join_domain()
     if [[ ! -f "$dns_record_file" ]]
     then
         log "--> DOMAIN NAME: ${domain_name}"
-        log "--> USERNAME: ${service_account_username}"
+        log "--> USERNAME: ${ad_service_account_username}"
         log "--> DOMAIN CONTROLLER: ${domain_controller_ip}"
 
         # default hostname has the form ip-10-0-0-1.us-west-1.compute.internal,
@@ -110,10 +110,10 @@ join_domain()
 
         # Wait for AD service account to be set up
         yum -y install openldap-clients
-        log "--> Wait for AD account ${service_account_username}@${domain_name} to be available"
-        until ldapwhoami -H ldap://${domain_controller_ip} -D ${service_account_username}@${domain_name} -w "$SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
+        log "--> Wait for AD account ${ad_service_account_username}@${domain_name} to be available"
+        until ldapwhoami -H ldap://${domain_controller_ip} -D ${ad_service_account_username}@${domain_name} -w "$AD_SERVICE_ACCOUNT_PASSWORD" -o nettimeout=1 > /dev/null 2>&1
         do
-            log "${service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
+            log "${ad_service_account_username}@${domain_name} not available yet, retrying in 10 seconds..."
             sleep 10
         done
 
@@ -138,9 +138,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$SERVICE_ACCOUNT_PASSWORD" | realm join --user="${service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]
@@ -161,7 +161,7 @@ join_domain()
         log "--> Registering with DNS"
         DOMAIN_UPPER=$(echo "${domain_name}" | tr '[:lower:]' '[:upper:]')
         IP_ADDRESS=$(hostname -I | grep -Eo '10.([0-9]*\.){2}[0-9]*')
-        echo "$SERVICE_ACCOUNT_PASSWORD" | kinit "${service_account_username}"@"$DOMAIN_UPPER"
+        echo "$AD_SERVICE_ACCOUNT_PASSWORD" | kinit "${ad_service_account_username}"@"$DOMAIN_UPPER"
         touch "$dns_record_file"
         echo "server ${domain_controller_ip}" > "$dns_record_file"
         echo "update add $VM_NAME.${domain_name} 600 a $IP_ADDRESS" >> "$dns_record_file"

--- a/modules/aws/centos-std/main.tf
+++ b/modules/aws/centos-std/main.tf
@@ -23,13 +23,13 @@ resource "aws_s3_bucket_object" "centos-std-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      aws_region               = var.aws_region, 
-      customer_master_key_id   = var.customer_master_key_id,
-      pcoip_registration_code  = var.pcoip_registration_code,
-      domain_controller_ip     = var.domain_controller_ip,
-      domain_name              = var.domain_name,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      aws_region                  = var.aws_region, 
+      customer_master_key_id      = var.customer_master_key_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      domain_controller_ip        = var.domain_controller_ip,
+      domain_name                 = var.domain_name,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/aws/centos-std/vars.tf
+++ b/modules/aws/centos-std/vars.tf
@@ -35,12 +35,12 @@ variable "domain_controller_ip" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/aws/dc/main.tf
+++ b/modules/aws/dc/main.tf
@@ -67,8 +67,8 @@ data "template_file" "new-domain-admin-user-script" {
     customer_master_key_id = var.customer_master_key_id
     host_name              = local.host_name
     domain_name            = var.domain_name
-    account_name           = var.service_account_username
-    account_password       = var.service_account_password
+    account_name           = var.ad_service_account_username
+    account_password       = var.ad_service_account_password
   }
 }
 

--- a/modules/aws/dc/vars.tf
+++ b/modules/aws/dc/vars.tf
@@ -25,12 +25,12 @@ variable "safe_mode_admin_password" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service account to be created"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service account password"
   type        = string
 }

--- a/modules/aws/win-gfx/main.tf
+++ b/modules/aws/win-gfx/main.tf
@@ -29,10 +29,10 @@ resource "aws_s3_bucket_object" "win-gfx-startup-script" {
       pcoip_agent_filename     = var.pcoip_agent_filename,
       pcoip_registration_code  = var.pcoip_registration_code,
 
-      domain_name              = var.domain_name,
-      admin_password           = var.admin_password,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      domain_name                 = var.domain_name,
+      admin_password              = var.admin_password,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/aws/win-gfx/vars.tf
+++ b/modules/aws/win-gfx/vars.tf
@@ -25,12 +25,12 @@ variable "domain_name" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -8,7 +8,7 @@ $LOG_FILE = "C:\Teradici\provisioning.log"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
-$DATA.Add("service_account_password", "${service_account_password}")
+$DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
@@ -26,11 +26,11 @@ function Decrypt-Credentials {
         $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
         $DATA."admin_password" = $StreamRead.ReadToEnd()
     
-        $ByteAry = [System.Convert]::FromBase64String("${service_account_password}")
+        $ByteAry = [System.Convert]::FromBase64String("${ad_service_account_password}")
         $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
         $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
         $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
-        $DATA."service_account_password" = $StreamRead.ReadToEnd()
+        $DATA."ad_service_account_password" = $StreamRead.ReadToEnd()
     }
     catch {
         "Error decrypting credentials: $_"
@@ -161,8 +161,8 @@ function Join-Domain {
 
     "Computer not part of a domain. Joining ${domain_name}..."
 
-    $username = "${service_account_username}" + "@" + "${domain_name}"
-    $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
+    $username = "${ad_service_account_username}" + "@" + "${domain_name}"
+    $password = ConvertTo-SecureString $DATA."ad_service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
     # Read "Name" tag for hostname

--- a/modules/aws/win-std/main.tf
+++ b/modules/aws/win-std/main.tf
@@ -29,10 +29,10 @@ resource "aws_s3_bucket_object" "win-std-startup-script" {
       pcoip_agent_filename     = var.pcoip_agent_filename,
       pcoip_registration_code  = var.pcoip_registration_code,
 
-      domain_name              = var.domain_name,
-      admin_password           = var.admin_password,
-      service_account_username = var.service_account_username,
-      service_account_password = var.service_account_password,
+      domain_name                 = var.domain_name,
+      admin_password              = var.admin_password,
+      ad_service_account_username = var.ad_service_account_username,
+      ad_service_account_password = var.ad_service_account_password,
     }
   )
 }

--- a/modules/aws/win-std/vars.tf
+++ b/modules/aws/win-std/vars.tf
@@ -25,12 +25,12 @@ variable "domain_name" {
   type        = string
 }
 
-variable "service_account_username" {
+variable "ad_service_account_username" {
   description = "Active Directory Service Account username"
   type        = string
 }
 
-variable "service_account_password" {
+variable "ad_service_account_password" {
   description = "Active Directory Service Account password"
   type        = string
 }

--- a/modules/aws/win-std/win-std-startup.ps1.tmpl
+++ b/modules/aws/win-std/win-std-startup.ps1.tmpl
@@ -8,7 +8,7 @@ $LOG_FILE = "C:\Teradici\provisioning.log"
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
-$DATA.Add("service_account_password", "${service_account_password}")
+$DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
@@ -26,11 +26,11 @@ function Decrypt-Credentials {
         $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
         $DATA."admin_password" = $StreamRead.ReadToEnd()
     
-        $ByteAry = [System.Convert]::FromBase64String("${service_account_password}")
+        $ByteAry = [System.Convert]::FromBase64String("${ad_service_account_password}")
         $MemStream = New-Object System.IO.MemoryStream($ByteAry, 0, $ByteAry.Length)
         $DecryptResp = Invoke-KMSDecrypt -CiphertextBlob $MemStream
         $StreamRead = New-Object System.IO.StreamReader($DecryptResp.Plaintext)
-        $DATA."service_account_password" = $StreamRead.ReadToEnd()
+        $DATA."ad_service_account_password" = $StreamRead.ReadToEnd()
     }
     catch {
         "Error decrypting credentials: $_"
@@ -161,8 +161,8 @@ function Join-Domain {
 
     "Computer not part of a domain. Joining ${domain_name}..."
 
-    $username = "${service_account_username}" + "@" + "${domain_name}"
-    $password = ConvertTo-SecureString $DATA."service_account_password" -AsPlainText -Force
+    $username = "${ad_service_account_username}" + "@" + "${domain_name}"
+    $password = ConvertTo-SecureString $DATA."ad_service_account_password" -AsPlainText -Force
     $cred = New-Object System.Management.Automation.PSCredential ($username, $password)
 
     # Read "Name" tag for hostname


### PR DESCRIPTION
For the AWS single connector deployment, all service_account variables
have been renamed to ad_service_account to avoid confusion with other
types of service accounts.

Signed-off-by: Edwin Pau <epau@teradici.com>