### PR TITLE
GCP: update .tfvars with new default OS images

### DIFF
--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -30,7 +30,7 @@ cac_instance_count_list = []
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20191113"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200129a"
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 ssl_key  = "/path/to/privkey.pem"
 ssl_cert = "/path/to/fullchain.pem"
@@ -40,24 +40,24 @@ win_gfx_instance_count = 0
 # win_gfx_accelerator_type = "nvidia-tesla-t4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2016-dc-v20191112"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2016-dc-v20191112"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-t4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20191121"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20191121"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -19,7 +19,7 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20191113"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200129a"
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 # Optional: Specify SSL certificate for Connector
 # ssl_key  = "/path/to/privkey.pem"
@@ -30,24 +30,24 @@ win_gfx_instance_count = 0
 # win_gfx_accelerator_type = "nvidia-tesla-t4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2016-dc-v20191112"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2016-dc-v20191112"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-t4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20191121"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20191121"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 


### PR DESCRIPTION
The base OS images in .tfvars were out-dated - updated to reflect the
latest default base OS images used in vars.tf.

Signed-off-by: Sherman Yin <syin@teradici.com>