### PR TITLE
Update GCP Windows startup scripts

### DIFF
--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -21,6 +21,26 @@ $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
+# Retry function, defaults to trying for 5 minutes with 10 seconds intervals
+function Retry([scriptblock]$Action, $Interval = 10, $Attempts = 30) {
+  $Current_Attempt = 0
+
+  while ($true) {
+    $Current_Attempt++
+    $rc = $Action.Invoke()
+
+    if ($?) { return $rc }
+
+    if ($Current_Attempt -ge $Attempts) {
+        Write-Error "Failed after $Current_Attempt attempt(s)." -InformationAction Continue
+        Throw
+    }
+
+    Write-Information "Attempt $Attempt failed. Retry in $Interval seconds..." -InformationAction Continue
+    Start-Sleep -Seconds $Interval
+  }
+}
+
 function Get-AuthToken {
     try {
         $response = Invoke-RestMethod -Method "Get" -Headers $METADATA_HEADERS -Uri $METADATA_AUTH_URI
@@ -127,11 +147,20 @@ function PCoIP-Agent-Install {
     if ("${pcoip_agent_filename}") {
         $agent_filename = "${pcoip_agent_filename}"
     } else {
-        $agent_filename = (New-Object System.Net.WebClient).DownloadString("${pcoip_agent_location}latest-graphics-agent.json") | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
+        $agent_latest = "${pcoip_agent_location}latest-graphics-agent.json"
+        $wc = New-Object System.Net.WebClient
+
+        "Checking for the latest PCoIP Agent version from $agent_latest..."
+        $string = Retry -Action {$wc.DownloadString($agent_latest)}
+
+        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
     $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
-    (New-Object System.Net.WebClient).DownloadFile($pcoipAgentInstallerUrl, $destFile)
+    $wc = New-Object System.Net.WebClient
+
+    "Downloading PCoIP Agent from $pcoipAgentInstallerUrl..."
+    Retry -Action {$wc.DownloadFile($pcoipAgentInstallerUrl, $destFile)}
     "Teradici PCoIP Agent downloaded: $agent_filename"
 
     "Installing agent..."
@@ -224,8 +253,15 @@ function Join-Domain {
         # - when password is incorrect (retry because user might not be added yet)
         # - when computer is already in domain
         Catch [System.InvalidOperationException] {
-            $_.Exception.Message
-            if (($Elapsed -ge $Timeout) -or ($_.Exception.GetType().FullName -match "AddComputerToSameDomain,Microsoft.PowerShell.Commands.AddComputerCommand")) {
+            $PSItem
+
+            if ($PSItem.FullyQualifiedErrorId -match "AddComputerToSameDomain,Microsoft.PowerShell.Commands.AddComputerCommand") {
+                "WARNING: Computer already joined to domain."
+                break
+            }
+
+            if ($Elapsed -ge $Timeout) {
+                "Timeout reached, exiting ..."
                 exit 1
             }
 
@@ -235,7 +271,7 @@ function Join-Domain {
             $Elapsed += $Interval
         }
         Catch {
-            $_.Exception.Message
+            $PSItem
             exit 1
         }
     } while ($Retry)
@@ -248,10 +284,21 @@ function Join-Domain {
 
     "Successfully joined '${domain_name}'"
     $global:restart = $true
+
+    # TODO: Find out why DNS entry is not always added after domain join.
+    # Sometimes the DNS entry for this workstation is not added in the Domain
+    # Controller after joining the domain, so explicitly add this machine to the
+    # DNS.
+    "Registering with DNS..."
+    do {
+        Start-Sleep -Seconds 5
+        Register-DnsClient
+    } while (!$?)
+    "Successfully registered with DNS."
 }
 
-
 if (Test-Path $LOG_FILE) {
+    Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
     "$LOG_FILE exists. Assume this startup script has run already."
     exit 0
 }
@@ -295,3 +342,4 @@ if ($global:restart) {
 } else {
     "No restart required"
 }
+

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -20,6 +20,26 @@ $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $global:restart = $false
 
+# Retry function, defaults to trying for 5 minutes with 10 seconds intervals
+function Retry([scriptblock]$Action, $Interval = 10, $Attempts = 30) {
+  $Current_Attempt = 0
+
+  while ($true) {
+    $Current_Attempt++
+    $rc = $Action.Invoke()
+
+    if ($?) { return $rc }
+
+    if ($Current_Attempt -ge $Attempts) {
+        Write-Error "Failed after $Current_Attempt attempt(s)." -InformationAction Continue
+        Throw
+    }
+
+    Write-Information "Attempt $Attempt failed. Retry in $Interval seconds..." -InformationAction Continue
+    Start-Sleep -Seconds $Interval
+  }
+}
+
 function Get-AuthToken {
     try {
         $response = Invoke-RestMethod -Method "Get" -Headers $METADATA_HEADERS -Uri $METADATA_AUTH_URI
@@ -84,11 +104,20 @@ function PCoIP-Agent-Install {
     if ("${pcoip_agent_filename}") {
         $agent_filename = "${pcoip_agent_filename}"
     } else {
-        $agent_filename = (New-Object System.Net.WebClient).DownloadString("${pcoip_agent_location}latest-standard-agent.json") | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
+        $agent_latest = "${pcoip_agent_location}latest-standard-agent.json"
+        $wc = New-Object System.Net.WebClient
+
+        "Checking for the latest PCoIP Agent version from $agent_latest..."
+        $string = Retry -Action {$wc.DownloadString($agent_latest)}
+
+        $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
     $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
-    (New-Object System.Net.WebClient).DownloadFile($pcoipAgentInstallerUrl, $destFile)
+    $wc = New-Object System.Net.WebClient
+
+    "Downloading PCoIP Agent from $pcoipAgentInstallerUrl..."
+    Retry -Action {$wc.DownloadFile($pcoipAgentInstallerUrl, $destFile)}
     "Teradici PCoIP Agent downloaded: $agent_filename"
 
     "Installing agent..."
@@ -181,8 +210,15 @@ function Join-Domain {
         # - when password is incorrect (retry because user might not be added yet)
         # - when computer is already in domain
         Catch [System.InvalidOperationException] {
-            $_.Exception.Message
-            if (($Elapsed -ge $Timeout) -or ($_.Exception.GetType().FullName -match "AddComputerToSameDomain,Microsoft.PowerShell.Commands.AddComputerCommand")) {
+            $PSItem
+
+            if ($PSItem.FullyQualifiedErrorId -match "AddComputerToSameDomain,Microsoft.PowerShell.Commands.AddComputerCommand") {
+                "WARNING: Computer already joined to domain."
+                break
+            }
+
+            if ($Elapsed -ge $Timeout) {
+                "Timeout reached, exiting ..."
                 exit 1
             }
 
@@ -192,7 +228,7 @@ function Join-Domain {
             $Elapsed += $Interval
         }
         Catch {
-            $_.Exception.Message
+            $PSItem
             exit 1
         }
     } while ($Retry)
@@ -205,10 +241,21 @@ function Join-Domain {
 
     "Successfully joined '${domain_name}'"
     $global:restart = $true
+
+    # TODO: Find out why DNS entry is not always added after domain join.
+    # Sometimes the DNS entry for this workstation is not added in the Domain
+    # Controller after joining the domain, so explicitly add this machine to the
+    # DNS.
+    "Registering with DNS..."
+    do {
+        Start-Sleep -Seconds 5
+        Register-DnsClient
+    } while (!$?)
+    "Successfully registered with DNS."
 }
 
-
 if (Test-Path $LOG_FILE) {
+    Start-Transcript -Path $LOG_FILE -Append -IncludeInvocationHeader
     "$LOG_FILE exists. Assume this startup script has run already."
     exit 0
 }


### PR DESCRIPTION
Changes from AWS Windows startup script were ported over to GCP
Windows startup scripts, which includes fixing an incorrect error
check, adding error handling when domain joining, and having retry
logic for downloading PCoIP Agent.

Signed-off-by: Edwin Pau <epau@teradici.com>