### PR TITLE
Use variables for PCoIP Agent download location

### DIFF
--- a/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -9,6 +9,8 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
 METADATA_IP="http://169.254.169.254"
+PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
+PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 log() {
     local message="$1"
@@ -156,11 +158,11 @@ install_pcoip_agent() {
         log "--> Start to install PCoIP agent ..."
         # Get the Teradici pubkey
         log "--> Get Teradici pubkey"
-        rpm --import https://downloads.teradici.com/rhel/teradici.pub.gpg
+        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
 
         # Get PCoIP repo
         log "--> Get Teradici PCoIP agent repo"
-        wget --retry-connrefused --tries=3 --waitretry=5 -O /etc/yum.repos.d/pcoip.repo https://downloads.teradici.com/rhel/pcoip.repo
+        wget --retry-connrefused --tries=3 --waitretry=5 -P /etc/yum.repos.d $PCOIP_AGENT_REPO_URL
 
         log "--> Install PCoIP graphics agent ..."
         yum -y install pcoip-agent-graphics

--- a/modules/aws/centos-gfx/main.tf
+++ b/modules/aws/centos-gfx/main.tf
@@ -31,6 +31,8 @@ resource "aws_s3_bucket_object" "centos-gfx-startup-script" {
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
       nvidia_driver_url           = var.nvidia_driver_url,
+      pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
+      pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
     }
   )
 }

--- a/modules/aws/centos-gfx/vars.tf
+++ b/modules/aws/centos-gfx/vars.tf
@@ -100,6 +100,16 @@ variable "admin_ssh_key_name" {
   type        = string
 }
 
+variable "pcoip_agent_repo_pubkey_url" {
+  description = "URL of Teradici repo public key"
+  default     = "https://downloads.teradici.com/rhel/teradici.pub.gpg"
+}
+
+variable "pcoip_agent_repo_url" {
+  description = "URL of Teradici PCoIP Graphics Agent"
+  default     = "https://downloads.teradici.com/rhel/pcoip.repo"
+}
+
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
   default     = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-9.1/NVIDIA-Linux-x86_64-430.46-grid.run"

--- a/modules/aws/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/aws/centos-std/centos-std-startup.sh.tmpl
@@ -9,6 +9,8 @@ exec > >(tee /var/log/user-data.log|logger -t user-data -s 2>/dev/console) 2>&1
 
 INST_LOG_FILE="/var/log/teradici/agent/install.log"
 METADATA_IP="http://169.254.169.254"
+PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
+PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 log() {
     local message="$1"
@@ -62,11 +64,11 @@ install_pcoip_agent() {
         log "--> Start to install PCoIP agent ..."
         # Get the Teradici pubkey
         log "--> Get Teradici pubkey"
-        rpm --import https://downloads.teradici.com/rhel/teradici.pub.gpg
+        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
 
         # Get PCoIP repo
         log "--> Get Teradici PCoIP agent repo"
-        wget --retry-connrefused --tries=3 --waitretry=5 -O /etc/yum.repos.d/pcoip.repo https://downloads.teradici.com/rhel/pcoip.repo
+        wget --retry-connrefused --tries=3 --waitretry=5 -P /etc/yum.repos.d $PCOIP_AGENT_REPO_URL
 
         log "--> Install PCoIP standard agent ..."
         yum -y install pcoip-agent-standard

--- a/modules/aws/centos-std/main.tf
+++ b/modules/aws/centos-std/main.tf
@@ -30,6 +30,8 @@ resource "aws_s3_bucket_object" "centos-std-startup-script" {
       domain_name                 = var.domain_name,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
+      pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
     }
   )
 }

--- a/modules/aws/centos-std/vars.tf
+++ b/modules/aws/centos-std/vars.tf
@@ -100,6 +100,16 @@ variable "admin_ssh_key_name" {
   type        = string
 }
 
+variable "pcoip_agent_repo_pubkey_url" {
+  description = "URL of Teradici repo public key"
+  default     = "https://downloads.teradici.com/rhel/teradici.pub.gpg"
+}
+
+variable "pcoip_agent_repo_url" {
+  description = "URL of Teradici PCoIP Standard Agent"
+  default     = "https://downloads.teradici.com/rhel/pcoip.repo"
+}
+
 variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []

--- a/modules/aws/win-gfx/main.tf
+++ b/modules/aws/win-gfx/main.tf
@@ -24,15 +24,14 @@ resource "aws_s3_bucket_object" "win-gfx-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      customer_master_key_id   = var.customer_master_key_id,
-      pcoip_agent_location     = var.pcoip_agent_location,
-      pcoip_agent_filename     = var.pcoip_agent_filename,
-      pcoip_registration_code  = var.pcoip_registration_code,
-
+      customer_master_key_id      = var.customer_master_key_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
       domain_name                 = var.domain_name,
       admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_location_url    = var.pcoip_agent_location_url,
+      pcoip_agent_filename        = var.pcoip_agent_filename,
     }
   )
 }

--- a/modules/aws/win-gfx/vars.tf
+++ b/modules/aws/win-gfx/vars.tf
@@ -87,7 +87,7 @@ variable "admin_password" {
   type        = string
 }
 
-variable "pcoip_agent_location" {
+variable "pcoip_agent_location_url" {
   description = "URL of Teradici PCoIP Graphics Agent"
   default     = "https://downloads.teradici.com/win/stable/"
 }

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
+$PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
+$PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -73,10 +75,12 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if ("${pcoip_agent_filename}") {
-        $agent_filename = "${pcoip_agent_filename}"
+    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
+        "Using user-specified PCoIP Agent filename..."
+        $agent_filename = $PCOIP_AGENT_FILENAME
     } else {
-        $agent_latest = "${pcoip_agent_location}latest-graphics-agent.json"
+        "Using default latest PCoIP Agent..."
+        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-graphics-agent.json"
         $wc = New-Object System.Net.WebClient
 
         "Checking for the latest PCoIP Agent version from $agent_latest..."
@@ -84,7 +88,7 @@ function PCoIP-Agent-Install {
 
         $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
-    $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
+    $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient
 

--- a/modules/aws/win-std/main.tf
+++ b/modules/aws/win-std/main.tf
@@ -24,15 +24,14 @@ resource "aws_s3_bucket_object" "win-std-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      customer_master_key_id   = var.customer_master_key_id,
-      pcoip_agent_location     = var.pcoip_agent_location,
-      pcoip_agent_filename     = var.pcoip_agent_filename,
-      pcoip_registration_code  = var.pcoip_registration_code,
-
+      customer_master_key_id      = var.customer_master_key_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
       domain_name                 = var.domain_name,
       admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_location_url    = var.pcoip_agent_location_url,
+      pcoip_agent_filename        = var.pcoip_agent_filename,
     }
   )
 }

--- a/modules/aws/win-std/vars.tf
+++ b/modules/aws/win-std/vars.tf
@@ -85,13 +85,13 @@ variable "admin_password" {
   type        = string
 }
 
-variable "pcoip_agent_location" {
+variable "pcoip_agent_location_url" {
   description = "URL of Teradici PCoIP Standard Agent"
   default     = "https://downloads.teradici.com/win/stable/"
 }
 
 variable "pcoip_agent_filename" {
-  description = "Filename of Teradici PCoIP Graphics Agent. Leave blank to download the latest."
+  description = "Filename of Teradici PCoIP Standard Agent. Leave blank to download the latest."
   default     = ""
 }
 

--- a/modules/aws/win-std/win-std-startup.ps1.tmpl
+++ b/modules/aws/win-std/win-std-startup.ps1.tmpl
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
+$PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
+$PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -73,10 +75,12 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if ("${pcoip_agent_filename}") {
-        $agent_filename = "${pcoip_agent_filename}"
+    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
+        "Using user-specified PCoIP Agent filename..."
+        $agent_filename = $PCOIP_AGENT_FILENAME
     } else {
-        $agent_latest = "${pcoip_agent_location}latest-standard-agent.json"
+        "Using default latest PCoIP Agent..."
+        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
         $wc = New-Object System.Net.WebClient
 
         "Checking for the latest PCoIP Agent version from $agent_latest..."
@@ -84,7 +88,7 @@ function PCoIP-Agent-Install {
 
         $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
-    $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
+    $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient
 

--- a/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -10,6 +10,8 @@ INST_LOG_FILE="/var/log/teradici/agent/install.log"
 METADATA_BASE_URI="http://metadata.google.internal/computeMetadata/v1/instance"
 METADATA_AUTH_URI="$METADATA_BASE_URI/service-accounts/default/token"
 DECRYPT_URI="https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
+PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
+PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 log() {
     local message="$1"
@@ -139,11 +141,11 @@ install_pcoip_agent() {
         log "--> Start to install pcoip agent ..."
         # Get the Teradici pubkey
         log "--> Get Teradici pubkey"
-        rpm --import https://downloads.teradici.com/rhel/teradici.pub.gpg
+        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
 
         # Get pcoip repo
         log "--> Get Teradici pcoip agent repo"
-        wget --retry-connrefused --tries=3 --waitretry=5 -O /etc/yum.repos.d/pcoip.repo https://downloads.teradici.com/rhel/pcoip.repo
+        wget --retry-connrefused --tries=3 --waitretry=5 -P /etc/yum.repos.d $PCOIP_AGENT_REPO_URL
 
         log "--> Install PCoIP graphics agent ..."
         yum -y install pcoip-agent-graphics

--- a/modules/gcp/centos-gfx/main.tf
+++ b/modules/gcp/centos-gfx/main.tf
@@ -31,6 +31,8 @@ resource "google_storage_bucket_object" "centos-gfx-startup-script" {
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
       nvidia_driver_url           = var.nvidia_driver_url,
+      pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
+      pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
     }
   )
 }

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -110,6 +110,16 @@ variable "ws_admin_ssh_pub_key_file" {
   type        = string
 }
 
+variable "pcoip_agent_repo_pubkey_url" {
+  description = "URL of Teradici repo public key"
+  default     = "https://downloads.teradici.com/rhel/teradici.pub.gpg"
+}
+
+variable "pcoip_agent_repo_url" {
+  description = "URL of Teradici PCoIP Graphics Agent"
+  default     = "https://downloads.teradici.com/rhel/pcoip.repo"
+}
+
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
   default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID9.1/NVIDIA-Linux-x86_64-430.46-grid.run"

--- a/modules/gcp/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-startup.sh.tmpl
@@ -10,6 +10,8 @@ INST_LOG_FILE="/var/log/teradici/agent/install.log"
 METADATA_BASE_URI="http://metadata.google.internal/computeMetadata/v1/instance"
 METADATA_AUTH_URI="$METADATA_BASE_URI/service-accounts/default/token"
 DECRYPT_URI="https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
+PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
+PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 log() {
     local message="$1"
@@ -58,11 +60,11 @@ install_pcoip_agent() {
         log "--> Start to install pcoip agent ..."
         # Get the Teradici pubkey
         log "--> Get Teradici pubkey"
-        rpm --import https://downloads.teradici.com/rhel/teradici.pub.gpg
+        rpm --import $PCOIP_AGENT_REPO_PUBKEY_URL
 
         # Get pcoip repo
         log "--> Get Teradici pcoip agent repo"
-        wget --retry-connrefused --tries=3 --waitretry=5 -O /etc/yum.repos.d/pcoip.repo https://downloads.teradici.com/rhel/pcoip.repo
+        wget --retry-connrefused --tries=3 --waitretry=5 -P /etc/yum.repos.d $PCOIP_AGENT_REPO_URL
 
         log "--> Install PCoIP standard agent ..."
         yum -y install pcoip-agent-standard

--- a/modules/gcp/centos-std/main.tf
+++ b/modules/gcp/centos-std/main.tf
@@ -30,6 +30,8 @@ resource "google_storage_bucket_object" "centos-std-startup-script" {
       domain_name                 = var.domain_name,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
+      pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
     }
   )
 }

--- a/modules/gcp/centos-std/vars.tf
+++ b/modules/gcp/centos-std/vars.tf
@@ -100,6 +100,16 @@ variable "ws_admin_ssh_pub_key_file" {
   type        = string
 }
 
+variable "pcoip_agent_repo_pubkey_url" {
+  description = "URL of Teradici repo public key"
+  default     = "https://downloads.teradici.com/rhel/teradici.pub.gpg"
+}
+
+variable "pcoip_agent_repo_url" {
+  description = "URL of Teradici PCoIP Standard Agent"
+  default     = "https://downloads.teradici.com/rhel/pcoip.repo"
+}
+
 variable "depends_on_hack" {
   description = "Workaround for Terraform Modules not supporting depends_on"
   default     = []

--- a/modules/gcp/win-gfx/main.tf
+++ b/modules/gcp/win-gfx/main.tf
@@ -25,14 +25,14 @@ resource "google_storage_bucket_object" "win-gfx-startup-script" {
     "${path.module}/${local.startup_script}.tmpl",
     {
       kms_cryptokey_id            = var.kms_cryptokey_id,
-      pcoip_agent_location        = var.pcoip_agent_location,
-      pcoip_agent_filename        = var.pcoip_agent_filename,
       pcoip_registration_code     = var.pcoip_registration_code,
       nvidia_driver_url           = var.nvidia_driver_url,
       domain_name                 = var.domain_name,
       admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_location_url    = var.pcoip_agent_location_url,
+      pcoip_agent_filename        = var.pcoip_agent_filename,
     }
   )
 }

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -105,7 +105,7 @@ variable "nvidia_driver_url" {
   default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID9.1/431.79_grid_win10_server2016_server2019_64bit_international.exe"
 }
 
-variable "pcoip_agent_location" {
+variable "pcoip_agent_location_url" {
   description = "URL of Teradici PCoIP Graphics Agent"
   default     = "https://downloads.teradici.com/win/stable/"
 }

--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -5,6 +5,8 @@
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
 $NVIDIA_DIR = "C:\Program Files\NVIDIA Corporation\NVSMI"
+$PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
+$PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
 
 $DECRYPT_URI = "https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
 
@@ -144,10 +146,12 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if ("${pcoip_agent_filename}") {
-        $agent_filename = "${pcoip_agent_filename}"
+    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
+        "Using user-specified PCoIP Agent filename..."
+        $agent_filename = $PCOIP_AGENT_FILENAME
     } else {
-        $agent_latest = "${pcoip_agent_location}latest-graphics-agent.json"
+        "Using default latest PCoIP Agent..."
+        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-graphics-agent.json"
         $wc = New-Object System.Net.WebClient
 
         "Checking for the latest PCoIP Agent version from $agent_latest..."
@@ -155,7 +159,7 @@ function PCoIP-Agent-Install {
 
         $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
-    $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
+    $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient
 

--- a/modules/gcp/win-std/main.tf
+++ b/modules/gcp/win-std/main.tf
@@ -24,15 +24,14 @@ resource "google_storage_bucket_object" "win-std-startup-script" {
   content = templatefile(
     "${path.module}/${local.startup_script}.tmpl",
     {
-      kms_cryptokey_id         = var.kms_cryptokey_id,
-      pcoip_agent_location     = var.pcoip_agent_location,
-      pcoip_agent_filename     = var.pcoip_agent_filename,
-      pcoip_registration_code  = var.pcoip_registration_code,
-
-      domain_name              = var.domain_name,
-      admin_password           = var.admin_password,
+      kms_cryptokey_id            = var.kms_cryptokey_id,
+      pcoip_registration_code     = var.pcoip_registration_code,
+      domain_name                 = var.domain_name,
+      admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,
       ad_service_account_password = var.ad_service_account_password,
+      pcoip_agent_location_url    = var.pcoip_agent_location_url,
+      pcoip_agent_filename        = var.pcoip_agent_filename,
     }
   )
 }

--- a/modules/gcp/win-std/vars.tf
+++ b/modules/gcp/win-std/vars.tf
@@ -90,13 +90,13 @@ variable "admin_password" {
   type        = string
 }
 
-variable "pcoip_agent_location" {
+variable "pcoip_agent_location_url" {
   description = "URL of Teradici PCoIP Standard Agent"
   default     = "https://downloads.teradici.com/win/stable/"
 }
 
 variable "pcoip_agent_filename" {
-  description = "Filename of Teradici PCoIP Graphics Agent. Leave blank to download the latest."
+  description = "Filename of Teradici PCoIP Standard Agent. Leave blank to download the latest."
   default     = ""
 }
 

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -4,6 +4,8 @@
 # LICENSE file in the root directory of this source tree.
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
+$PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
+$PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
 
 $DECRYPT_URI = "https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
 
@@ -101,10 +103,12 @@ function PCoIP-Agent-Install {
     }
 
     $agentInstallerDLDirectory = "C:\Teradici"
-    if ("${pcoip_agent_filename}") {
-        $agent_filename = "${pcoip_agent_filename}"
+    if (![string]::IsNullOrEmpty($PCOIP_AGENT_FILENAME)) {
+        "Using user-specified PCoIP Agent filename..."
+        $agent_filename = $PCOIP_AGENT_FILENAME
     } else {
-        $agent_latest = "${pcoip_agent_location}latest-standard-agent.json"
+        "Using default latest PCoIP Agent..."
+        $agent_latest = $PCOIP_AGENT_LOCATION_URL + "latest-standard-agent.json"
         $wc = New-Object System.Net.WebClient
 
         "Checking for the latest PCoIP Agent version from $agent_latest..."
@@ -112,7 +116,7 @@ function PCoIP-Agent-Install {
 
         $agent_filename = $string | ConvertFrom-Json | Select-Object -ExpandProperty "filename"
     }
-    $pcoipAgentInstallerUrl = "${pcoip_agent_location}$agent_filename"
+    $pcoipAgentInstallerUrl = $PCOIP_AGENT_LOCATION_URL + $agent_filename
     $destFile = $agentInstallerDLDirectory + '\' + $agent_filename
     $wc = New-Object System.Net.WebClient
 


### PR DESCRIPTION
As part of the startup scripts for CentOS machines, the download
locations for PCoIP agent has been changed to use terraform variables
instead for better flexibility and to remain consistent with the
Windows startup scripts. Windows startup scripts were modified
to match the style of the Centos startup scripts using global
variables.

Signed-off-by: Edwin Pau <epau@teradici.com>