### PR TITLE
Revert GCP GPUs to use P4 again

### DIFF
--- a/deployments/gcp/dc-only/terraform.tfvars.sample
+++ b/deployments/gcp/dc-only/terraform.tfvars.sample
@@ -2,8 +2,8 @@
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
-# gcp_region           = "us-west1"
-# gcp_zone             = "us-west1-b"
+# gcp_region           = "us-west2"
+# gcp_zone             = "us-west2-b"
 
 # prefix = "myprefix"
 

--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -22,14 +22,14 @@ variable "gcp_service_account" {
 
 variable "gcp_region" {
   description = "GCP region"
-  default     = "us-west1"
+  default     = "us-west2"
 }
 
 variable "gcp_zone" {
   description = "GCP zone"
 
-  # Default to us-west1-b because Tesla T4 Workstation GPUs available here
-  default = "us-west1-b"
+  # Default to us-west2-b because Tesla P4 Workstation GPUs available here
+  default = "us-west2-b"
 }
 
 variable "prefix" {

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -2,8 +2,8 @@
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
-# gcp_region           = "us-west1"
-# gcp_zone             = "us-west1-b"
+# gcp_region           = "us-west2"
+# gcp_zone             = "us-west2-b"
 
 # prefix = "myprefix"
 
@@ -19,8 +19,8 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 
 # Specify the regions, zones and number of connectors to create per region.
 # For example:
-#   cac_region_list         = ["us-west1",    "europe-west4",   "asia-southeast1"]
-#   cac_zone_list           = ["us-west1-b",  "europe-west4-b", "asia-southeast1-b"]
+#   cac_region_list         = ["us-west2",    "europe-west4",   "asia-southeast1"]
+#   cac_zone_list           = ["us-west2-b",  "europe-west4-b", "asia-southeast1-b"]
 #   cac_subnet_cidr_list    = ["10.0.1.0/24", "10.1.1.0/24",    "10.2.1.0/24"]
 #   cac_instance_count_list = [2,             3,                4]
 cac_region_list         = []
@@ -37,7 +37,7 @@ ssl_cert = "/path/to/fullchain.pem"
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"
-# win_gfx_accelerator_type = "nvidia-tesla-t4-vws"
+# win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
 # win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
@@ -49,7 +49,7 @@ win_std_instance_count = 0
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"
-# centos_gfx_accelerator_type = "nvidia-tesla-t4-vws"
+# centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
 # centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -22,14 +22,14 @@ variable "gcp_service_account" {
 
 variable "gcp_region" {
   description = "GCP region"
-  default     = "us-west1"
+  default     = "us-west2"
 }
 
 variable "gcp_zone" {
   description = "GCP zone"
 
-  # Default to us-west1-b because Tesla T4 Workstation GPUs available here
-  default = "us-west1-b"
+  # Default to us-west2-b because Tesla P4 Workstation GPUs available here
+  default = "us-west2-b"
 }
 
 variable "prefix" {
@@ -206,7 +206,7 @@ variable "win_gfx_machine_type" {
 
 variable "win_gfx_accelerator_type" {
   description = "Accelerator type for Windows Graphics Workstations"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "win_gfx_accelerator_count" {
@@ -256,7 +256,7 @@ variable "centos_gfx_machine_type" {
 
 variable "centos_gfx_accelerator_type" {
   description = "Accelerator type for CentOS Graphics Workstations"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "centos_gfx_accelerator_count" {

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -2,8 +2,8 @@
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
-# gcp_region           = "us-west1"
-# gcp_zone             = "us-west1-b"
+# gcp_region           = "us-west2"
+# gcp_zone             = "us-west2-b"
 
 # prefix = "myprefix"
 
@@ -27,7 +27,7 @@ cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"
-# win_gfx_accelerator_type = "nvidia-tesla-t4-vws"
+# win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
 # win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200211"
@@ -39,7 +39,7 @@ win_std_instance_count = 0
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"
-# centos_gfx_accelerator_type = "nvidia-tesla-t4-vws"
+# centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
 # centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200205"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -22,14 +22,14 @@ variable "gcp_service_account" {
 
 variable "gcp_region" {
   description = "GCP region"
-  default     = "us-west1"
+  default     = "us-west2"
 }
 
 variable "gcp_zone" {
   description = "GCP zone"
 
-  # Default to us-west1-b because Tesla T4 Workstation GPUs available here
-  default = "us-west1-b"
+  # Default to us-west2-b because Tesla P4 Workstation GPUs available here
+  default = "us-west2-b"
 }
 
 variable "prefix" {
@@ -186,7 +186,7 @@ variable "win_gfx_machine_type" {
 
 variable "win_gfx_accelerator_type" {
   description = "Accelerator type for Windows Graphics Workstations"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "win_gfx_accelerator_count" {
@@ -236,7 +236,7 @@ variable "centos_gfx_machine_type" {
 
 variable "centos_gfx_accelerator_type" {
   description = "Accelerator type for CentOS Graphics Workstations"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "centos_gfx_accelerator_count" {

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -26,7 +26,7 @@ SA_ROLES    = [
 ]
 
 PROJECT_ID = os.environ['GOOGLE_CLOUD_PROJECT']
-GCP_REGION = 'us-west1'
+GCP_REGION = 'us-west2'
 REQUIRED_APIS = [
     'deploymentmanager.googleapis.com',
     'cloudkms.googleapis.com',
@@ -73,8 +73,8 @@ Next steps:
   3. Select connector "quickstart_cac_<timestamp>"
   4. Fill in the form according to your preferences. Note that the following
      values must be used for their respective fields:
-       Region:                   "us-west1"
-       Zone:                     "us-west1-b"
+       Region:                   "us-west2"
+       Zone:                     "us-west2-b"
        Network:                  "vpc-cas"
        Subnetowrk:               "subnet-ws"
        Domain name:              "example.com"
@@ -416,7 +416,7 @@ if __name__ == '__main__':
             mycam.machine_add_existing(
                 hostname,
                 PROJECT_ID,
-                'us-west1-b',
+                'us-west2-b',
                 deployment
             )
 

--- a/quickstart/tutorial.md
+++ b/quickstart/tutorial.md
@@ -33,14 +33,14 @@ Enter the number of workstations to create.
 Parameter | Description
 --- | ---
 scent | Standard CentOS 7 Workstation
-gcent | CentOS 7 with NVIDIA Tesla T4 Virtual Workstation GPU
-swin | Windows Server 2016 Workstation
-gwin | Windows Server 2016 with NVIDIA Tesla T4 Virtual Workstation GPU
+gcent | CentOS 7 with NVIDIA Tesla P4 Virtual Workstation GPU
+swin | Windows Server 2019 Workstation
+gwin | Windows Server 2019 with NVIDIA Tesla P4 Virtual Workstation GPU
 
 ### Check your Quota
 Please ensure there is sufficient CPU, SSD, GPU, etc. quota in your project for the chosen number of workstations, on top of the Domain Controller (DC) and Cloud Access Connector (CAC) which will also be created.
 
-The deployment will be created in **us-west1-b** and have the following specs:
+The deployment will be created in **us-west2-b** and have the following specs:
 
 VM | vCPUs | Memory (GB) | SSD (GB) | GPU 
 ---|---|---|---|--- 
@@ -91,8 +91,8 @@ The script should take approximately 25 minutes to run.
 4. Fill in the form according to your preferences. Note that the following
    values must be used for their respective fields:
 ```
-Region:                   "us-west1"
-Zone:                     "us-west1-b"
+Region:                   "us-west2"
+Zone:                     "us-west2-b"
 Network:                  "vpc-cas"
 Subnetowrk:               "subnet-ws"
 Domain name:              "example.com"


### PR DESCRIPTION
This change reverts GCP deployment to use P4 GPUs again as the 
default for graphics workstations. Terraform deployments with T4 GPU
workstations were not deploying consistently due to a lack of GCP
resource availability in the us-west1-b zone. Default zone has been
reverted back to us-west2-b since this is where the P4 GPUs are
available.

Signed-off-by: Edwin Pau <epau@teradici.com>