### PR TITLE
Revert GCP GPUs to use P4 (modules)

### DIFF
--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -62,7 +62,7 @@ variable "bucket_name" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Cloud Access Connector"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "subnet" {

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -47,7 +47,7 @@ variable "ad_service_account_password" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Workstation"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "bucket_name" {
@@ -82,7 +82,7 @@ variable "machine_type" {
 
 variable "accelerator_type" {
   description = "Accelerator type for the Workstation"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "accelerator_count" {

--- a/modules/gcp/centos-std/vars.tf
+++ b/modules/gcp/centos-std/vars.tf
@@ -52,7 +52,7 @@ variable "bucket_name" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Workstation"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "subnet" {

--- a/modules/gcp/dc/vars.tf
+++ b/modules/gcp/dc/vars.tf
@@ -52,7 +52,7 @@ variable "bucket_name" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Domain Controller"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "subnet" {

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -47,7 +47,7 @@ variable "bucket_name" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Workstation"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "subnet" {
@@ -77,7 +77,7 @@ variable "machine_type" {
 
 variable "accelerator_type" {
   description = "Accelerator type for the Workstation"
-  default     = "nvidia-tesla-t4-vws"
+  default     = "nvidia-tesla-p4-vws"
 }
 
 variable "accelerator_count" {

--- a/modules/gcp/win-std/vars.tf
+++ b/modules/gcp/win-std/vars.tf
@@ -47,7 +47,7 @@ variable "bucket_name" {
 
 variable "gcp_zone" {
   description = "Zone to deploy the Workstation"
-  default     = "us-west1-b"
+  default     = "us-west2-b"
 }
 
 variable "subnet" {


### PR DESCRIPTION
This change reverts GCP deployment to use P4 GPUs again as the default
for graphics workstations. Terraform deployments with T4 GPU
workstations were not deploying consistently due to a lack of GCP
resource availability in the us-west1-b zone. Default zone has been
reverted to use us-west2-b.

Signed-off-by: Edwin Pau <epau@teradici.com>