### PR TITLE
AWS: update Widnows AMI to 2020.02.12

### DIFF
--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -32,7 +32,7 @@ win_std_instance_count = 0
 # win_std_instance_type = "t2.xlarge"
 # win_std_disk_size_gb  = 50
 # win_std_ami_owner     = "amazon"
-# win_std_ami_name      = "Windows_Server-2016-English-Full-Base-2019.11.13"
+# win_std_ami_name      = "Windows_Server-2016-English-Full-Base-2020.02.12"
 
 # REQUIRED: ensure the AWS account used has subscribed to the "CentOS 7 (x86_64)
 # - with Updates HVM" image using the AWS dashboard at

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -62,7 +62,7 @@ variable "dc_ami_owner" {
 
 variable "dc_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default = "Windows_Server-2016-English-Full-Base-2019.11.13"
+  default     = "Windows_Server-2016-English-Full-Base-2020.02.12"
 }
 
 variable "domain_name" {
@@ -210,7 +210,7 @@ variable "win_std_ami_owner" {
 
 variable "win_std_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "Windows_Server-2016-English-Full-Base-2019.11.13"
+  default     = "Windows_Server-2016-English-Full-Base-2020.02.12"
 }
 
 variable "centos_gfx_instance_count" {


### PR DESCRIPTION
2019.11.13 version of Windows Server 2016 AMI is no longer available.
Updated to 2020.02.12.

Signed-off-by: Sherman Yin <syin@teradici.com>