### PR TITLE
GCP: Allow restriction of PCoIP Clients

### DIFF
--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -40,7 +40,7 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-dns.name}",
+    "${google_compute_firewall.allow-google-dns.name}",
     "${google_compute_firewall.allow-rdp.name}",
     "${google_compute_firewall.allow-winrm.name}",
     "${google_compute_firewall.allow-icmp.name}",
@@ -73,9 +73,9 @@ module "cac-igm" {
   gcp_zone_list = var.cac_zone_list
   subnet_list   = google_compute_subnetwork.cac-subnets[*].self_link
   network_tags  = [
+    "${google_compute_firewall.allow-google-health-check.name}",
     "${google_compute_firewall.allow-ssh.name}",
     "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-https.name}",
     "${google_compute_firewall.allow-pcoip.name}",
   ]
 

--- a/deployments/gcp/multi-region/networking.tf
+++ b/deployments/gcp/multi-region/networking.tf
@@ -65,11 +65,13 @@ resource "google_compute_firewall" "allow-ssh" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-ssh"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
-resource "google_compute_firewall" "allow-https" {
-  name    = "${local.prefix}fw-allow-https"
+# Open TCP/443 for Google Load balancers to perform health checks
+# https://cloud.google.com/load-balancing/docs/health-checks
+resource "google_compute_firewall" "allow-google-health-check" {
+  name    = "${local.prefix}fw-allow-google-health-check"
   network = google_compute_network.vpc.self_link
 
   allow {
@@ -77,8 +79,8 @@ resource "google_compute_firewall" "allow-https" {
     ports    = ["443"]
   }
 
-  target_tags   = ["${local.prefix}fw-allow-https"]
-  source_ranges = ["0.0.0.0/0"]
+  target_tags   = ["${local.prefix}fw-allow-google-health-check"]
+  source_ranges = ["35.191.0.0/16", "130.211.0.0/22"]
 }
 
 resource "google_compute_firewall" "allow-rdp" {
@@ -95,7 +97,7 @@ resource "google_compute_firewall" "allow-rdp" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-rdp"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-winrm" {
@@ -108,7 +110,7 @@ resource "google_compute_firewall" "allow-winrm" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-winrm"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-icmp" {
@@ -120,13 +122,17 @@ resource "google_compute_firewall" "allow-icmp" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-icmp"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-pcoip" {
   name    = "${local.prefix}fw-allow-pcoip"
   network = google_compute_network.vpc.self_link
 
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
   allow {
     protocol = "tcp"
     ports    = ["4172"]
@@ -137,11 +143,13 @@ resource "google_compute_firewall" "allow-pcoip" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-pcoip"]
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.allowed_client_cidrs
 }
 
-resource "google_compute_firewall" "allow-dns" {
-  name    = "${local.prefix}fw-allow-dns"
+# Open TCP/UDP/53 for Google Cloud DNS managed zone
+# https://cloud.google.com/dns/zones
+resource "google_compute_firewall" "allow-google-dns" {
+  name    = "${local.prefix}fw-allow-google-dns"
   network = google_compute_network.vpc.self_link
 
   allow {
@@ -153,7 +161,7 @@ resource "google_compute_firewall" "allow-dns" {
     ports    = ["53"]
   }
 
-  target_tags   = ["${local.prefix}fw-allow-dns"]
+  target_tags   = ["${local.prefix}fw-allow-google-dns"]
   source_ranges = ["35.199.192.0/19"]
 }
 

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -8,9 +8,14 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 # prefix = "myprefix"
 
 # By default, ICMP, SSH, RDP and WinRM are only allowed from the Terraform host.
-# Define allowed_cidr to open the VPC firewall to additional IP addresses or 
-# CIDRs.
-# allowed_cidr = ["a.b.c.d", "e.f.g.0/24"]
+# Define allowed_admin_cidrs to open the VPC firewall to additional IP addresses
+# or CIDRs.
+# allowed_admin_cidrs = ["a.b.c.d", "e.f.g.0/24"]
+
+# By default, PCoIP clients are allowed from any IP (0.0.0.0/0). Define
+# allowed_client_cidrs to restrict IP addresses from which PCoIP clients can
+# connect to remote workstations.
+# allowed_client_cidrs = ["a.b.c.d", "e.f.g.0/24"]
 
 # domain_name = "example.com"
 

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -37,9 +37,14 @@ variable "prefix" {
   default     = ""
 }
 
-variable "allowed_cidr" {
+variable "allowed_admin_cidrs" {
   description = "Open VPC firewall to allow ICMP, SSH, WinRM and RDP from these IP Addresses or CIDR ranges. e.g. ['a.b.c.d', 'e.f.g.0/24']"
   default     = []
+}
+
+variable "allowed_client_cidrs" {
+  description = "Open VPC firewall to allow PCoIP connections from these IP Addresses or CIDR ranges. e.g. ['a.b.c.d', 'e.f.g.0/24']"
+  default     = ["0.0.0.0/0"]
 }
 
 variable "vpc_name" {

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -40,7 +40,7 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-dns.name}",
+    "${google_compute_firewall.allow-google-dns.name}",
     "${google_compute_firewall.allow-rdp.name}",
     "${google_compute_firewall.allow-winrm.name}",
     "${google_compute_firewall.allow-icmp.name}",
@@ -74,7 +74,6 @@ module "cac" {
   network_tags = [
     "${google_compute_firewall.allow-ssh.name}",
     "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-https.name}",
     "${google_compute_firewall.allow-pcoip.name}",
   ]
 

--- a/deployments/gcp/single-connector/networking.tf
+++ b/deployments/gcp/single-connector/networking.tf
@@ -65,20 +65,7 @@ resource "google_compute_firewall" "allow-ssh" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-ssh"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
-}
-
-resource "google_compute_firewall" "allow-https" {
-  name    = "${local.prefix}fw-allow-https"
-  network = google_compute_network.vpc.self_link
-
-  allow {
-    protocol = "tcp"
-    ports    = ["443"]
-  }
-
-  target_tags   = ["${local.prefix}fw-allow-https"]
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-rdp" {
@@ -95,7 +82,7 @@ resource "google_compute_firewall" "allow-rdp" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-rdp"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-winrm" {
@@ -108,7 +95,7 @@ resource "google_compute_firewall" "allow-winrm" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-winrm"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-icmp" {
@@ -120,13 +107,17 @@ resource "google_compute_firewall" "allow-icmp" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-icmp"]
-  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_cidr)
+  source_ranges = concat([chomp(data.http.myip.body)], var.allowed_admin_cidrs)
 }
 
 resource "google_compute_firewall" "allow-pcoip" {
   name    = "${local.prefix}fw-allow-pcoip"
   network = google_compute_network.vpc.self_link
 
+  allow {
+    protocol = "tcp"
+    ports    = ["443"]
+  }
   allow {
     protocol = "tcp"
     ports    = ["4172"]
@@ -137,11 +128,13 @@ resource "google_compute_firewall" "allow-pcoip" {
   }
 
   target_tags   = ["${local.prefix}fw-allow-pcoip"]
-  source_ranges = ["0.0.0.0/0"]
+  source_ranges = var.allowed_client_cidrs
 }
 
-resource "google_compute_firewall" "allow-dns" {
-  name    = "${local.prefix}fw-allow-dns"
+# Open TCP/UDP/53 for Google Cloud DNS managed zone
+# https://cloud.google.com/dns/zones
+resource "google_compute_firewall" "allow-google-dns" {
+  name    = "${local.prefix}fw-allow-google-dns"
   network = google_compute_network.vpc.self_link
 
   allow {
@@ -153,7 +146,7 @@ resource "google_compute_firewall" "allow-dns" {
     ports    = ["53"]
   }
 
-  target_tags   = ["${local.prefix}fw-allow-dns"]
+  target_tags   = ["${local.prefix}fw-allow-google-dns"]
   source_ranges = ["35.199.192.0/19"]
 }
 

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -8,9 +8,14 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 # prefix = "myprefix"
 
 # By default, ICMP, SSH, RDP and WinRM are only allowed from the Terraform host.
-# Define allowed_cidr to open the VPC firewall to additional IP addresses or 
-# CIDRs.
-# allowed_cidr = ["a.b.c.d", "e.f.g.0/24"]
+# Define allowed_admin_cidrs to open the VPC firewall to additional IP addresses
+# or CIDRs.
+# allowed_admin_cidrs = ["a.b.c.d", "e.f.g.0/24"]
+
+# By default, PCoIP clients are allowed from any IP (0.0.0.0/0). Define
+# allowed_client_cidrs to restrict IP addresses from which PCoIP clients can
+# connect to remote workstations.
+# allowed_client_cidrs = ["a.b.c.d", "e.f.g.0/24"]
 
 # domain_name = "example.com"
 

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -37,9 +37,14 @@ variable "prefix" {
   default     = ""
 }
 
-variable "allowed_cidr" {
+variable "allowed_admin_cidrs" {
   description = "Open VPC firewall to allow ICMP, SSH, WinRM and RDP from these IP Addresses or CIDR ranges. e.g. ['a.b.c.d', 'e.f.g.0/24']"
   default     = []
+}
+
+variable "allowed_client_cidrs" {
+  description = "Open VPC firewall to allow PCoIP connections from these IP Addresses or CIDR ranges. e.g. ['a.b.c.d', 'e.f.g.0/24']"
+  default     = ["0.0.0.0/0"]
 }
 
 variable "vpc_name" {


### PR DESCRIPTION
Give users an option to restrict the IP address range from which PCoIP
clients can connect to the remote workstations.

Also re-organized the firewall rules.

Signed-off-by: Sherman Yin <syin@teradici.com>