### PR TITLE
GCP: Add idle shutdown for Terraform deployed WS

### DIFF
--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -109,6 +109,10 @@ module "win-gfx" {
   gcp_zone         = var.gcp_zone
   subnet           = google_compute_subnetwork.ws-subnet.self_link
   enable_public_ip = var.enable_workstation_public_ip
+
+  enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
+  minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
     "${google_compute_firewall.allow-rdp.name}",
@@ -144,6 +148,10 @@ module "win-std" {
   gcp_zone         = var.gcp_zone
   subnet           = google_compute_subnetwork.ws-subnet.self_link
   enable_public_ip = var.enable_workstation_public_ip
+
+  enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
+  minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
     "${google_compute_firewall.allow-rdp.name}",
@@ -177,6 +185,10 @@ module "centos-gfx" {
   gcp_zone         = var.gcp_zone
   subnet           = google_compute_subnetwork.ws-subnet.self_link
   enable_public_ip = var.enable_workstation_public_ip
+
+  enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
+  minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
     "${google_compute_firewall.allow-ssh.name}",
@@ -215,6 +227,10 @@ module "centos-std" {
   gcp_zone         = var.gcp_zone
   subnet           = google_compute_subnetwork.ws-subnet.self_link
   enable_public_ip = var.enable_workstation_public_ip
+
+  enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
+  minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
     "${google_compute_firewall.allow-ssh.name}",

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -112,6 +112,7 @@ module "win-gfx" {
 
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
   minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+  minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
@@ -151,6 +152,7 @@ module "win-std" {
 
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
   minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+  minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
@@ -188,6 +190,7 @@ module "centos-gfx" {
 
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
   minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+  minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",
@@ -230,6 +233,7 @@ module "centos-std" {
 
   enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown
   minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown
+  minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
     "${google_compute_firewall.allow-icmp.name}",

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -189,6 +189,11 @@ variable "minutes_idle_before_shutdown" {
   default     = 240
 }
 
+variable "minutes_cpu_polling_interval" {
+  description = "Polling interval for checking CPU utilization to determine if machine is idle, must be between 1 and 60"
+  default     = 15
+}
+
 variable "win_gfx_instance_count" {
   description = "Number of Windows Grpahics Workstations"
   default     = 0

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -179,6 +179,16 @@ variable "enable_workstation_public_ip" {
   default     = false
 }
 
+variable "enable_workstation_idle_shutdown" {
+  description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
+  default     = true
+}
+
+variable "minutes_idle_before_shutdown" {
+  description = "Minimum idle time for Workstations before auto idle shutdown, must be between 5 and 10000"
+  default     = 240
+}
+
 variable "win_gfx_instance_count" {
   description = "Number of Windows Grpahics Workstations"
   default     = 0

--- a/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -13,9 +13,33 @@ DECRYPT_URI="https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
 PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
 PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
+ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
+AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
+
 log() {
     local message="$1"
     echo "[$(date)] $${message}" | tee -a "$INST_LOG_FILE"
+}
+
+retry() {
+    local retries=0
+    local max_retries=3
+    until [[ $retries -ge $max_retries ]]
+    do  
+    # Break if command succeeds, or log the retry if command fails.
+        $@ && break || {
+
+            log "--> Failed to run command. $${@}"
+            log "--> Retries left... $(( $max_retries - $retries ))"
+            ((n++))
+            sleep 10;
+        }
+    done
+
+    if [[ $retries -eq $max_retries ]]
+    then
+        return 1
+    fi
 }
 
 get_credentials() {
@@ -173,6 +197,28 @@ install_pcoip_agent() {
     fi
 }
 
+install_idle_shutdown() {
+    log "--> Installing idle shutdown..."
+    mkdir /tmp/idleShutdown
+
+    retry wget "https://raw.githubusercontent.com/teradici/deploy/master/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh" -O /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh
+    
+    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && sudo chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
+
+    INSTALL_OPTS="--idle-timer $${AUTO_SHUTDOWN_IDLE_TIMER}"
+    if [[ "$${ENABLE_AUTO_SHUTDOWN}" = "false" ]]; then
+        INSTALL_OPTS="$${INSTALL_OPTS} --disabled"
+    fi
+    
+    retry /tmp/idleShutdown/Install-Idle-Shutdown.sh $${INSTALL_OPTS}
+
+    exitCode=$?
+    if [[ $exitCode -ne 0 ]]; then
+        log "--> Failed to install idle shutdown."
+        exit 1
+    fi
+}
+
 # Join domain
 join_domain()
 {
@@ -294,6 +340,8 @@ else
     enable_persistence_mode
 
     install_pcoip_agent
+
+    install_idle_shutdown
 
     log "--> Installation is completed !!!"
 

--- a/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -15,6 +15,7 @@ PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
 AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
+CPU_POLLING_INTERVAL=${minutes_cpu_polling_interval}
 
 log() {
     local message="$1"
@@ -203,8 +204,9 @@ install_idle_shutdown() {
 
     retry wget "https://raw.githubusercontent.com/teradici/deploy/master/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh" -O /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh
     
-    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && sudo chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
+    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
 
+    log "--> Setting auto shutdown idle timer to $${AUTO_SHUTDOWN_IDLE_TIMER} minutes"
     INSTALL_OPTS="--idle-timer $${AUTO_SHUTDOWN_IDLE_TIMER}"
     if [[ "$${ENABLE_AUTO_SHUTDOWN}" = "false" ]]; then
         INSTALL_OPTS="$${INSTALL_OPTS} --disabled"
@@ -216,6 +218,12 @@ install_idle_shutdown() {
     if [[ $exitCode -ne 0 ]]; then
         log "--> Failed to install idle shutdown."
         exit 1
+    fi
+
+    if [[ $CPU_POLLING_INTERVAL -ne 15 ]]; then
+        log "--> Setting CPU polling interval to $${CPU_POLLING_INTERVAL} minutes"
+        sed -i "s/OnUnitActiveSec=15min/OnUnitActiveSec=$${CPU_POLLING_INTERVAL}min/g" /etc/systemd/system/CAMIdleShutdown.timer.d/CAMIdleShutdown.conf
+        systemctl daemon-reload
     fi
 }
 

--- a/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -32,7 +32,7 @@ retry() {
 
             log "--> Failed to run command. $${@}"
             log "--> Retries left... $(( $max_retries - $retries ))"
-            ((n++))
+            ((retries++))
             sleep 10;
         }
     done

--- a/modules/gcp/centos-gfx/main.tf
+++ b/modules/gcp/centos-gfx/main.tf
@@ -36,6 +36,7 @@ resource "google_storage_bucket_object" "centos-gfx-startup-script" {
 
       enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
       minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
+      minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
     }
   )
 }

--- a/modules/gcp/centos-gfx/main.tf
+++ b/modules/gcp/centos-gfx/main.tf
@@ -33,6 +33,9 @@ resource "google_storage_bucket_object" "centos-gfx-startup-script" {
       nvidia_driver_url           = var.nvidia_driver_url,
       pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
       pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
+
+      enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
+      minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
     }
   )
 }

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -75,6 +75,11 @@ variable "minutes_idle_before_shutdown" {
   default     = 240
 }
 
+variable "minutes_cpu_polling_interval" {
+  description = "Polling interval for checking CPU utilization to determine if machine is idle, must be between 1 and 60"
+  default     = 15
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -65,6 +65,16 @@ variable "enable_public_ip" {
   default     = false
 }
 
+variable "enable_workstation_idle_shutdown" {
+  description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
+  default     = true
+}
+
+variable "minutes_idle_before_shutdown" {
+  description = "Minimum idle time for Workstations before auto idle shutdown, must be between 5 and 10000"
+  default     = 240
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-startup.sh.tmpl
@@ -13,9 +13,33 @@ DECRYPT_URI="https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
 PCOIP_AGENT_REPO_PUBKEY_URL=${pcoip_agent_repo_pubkey_url}
 PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
+ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
+AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
+
 log() {
     local message="$1"
     echo "[$(date)] $${message}" | tee -a "$INST_LOG_FILE"
+}
+
+retry() {
+    local retries=0
+    local max_retries=3
+    until [[ $retries -ge $max_retries ]]
+    do  
+    # Break if command succeeds, or log then retry if command fails.
+        $@ && break || {
+
+            log "--> Failed to run command. $${@}"
+            log "--> Retries left... $(( $max_retries - $retries ))"
+            ((n++))
+            sleep 10;
+        }
+    done
+
+    if [[ $retries -eq $max_retries ]]
+    then
+        return 1
+    fi
 }
 
 get_credentials() {
@@ -89,6 +113,28 @@ install_pcoip_agent() {
             sleep 10
         done
         log "--> Pcoip agent is registered successfully"
+    fi
+}
+
+install_idle_shutdown() {
+    log "--> Installing idle shutdown..."
+    mkdir /tmp/idleShutdown
+
+    retry wget "https://raw.githubusercontent.com/teradici/deploy/master/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh" -O /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh
+    
+    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && sudo chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
+
+    INSTALL_OPTS="--idle-timer $${AUTO_SHUTDOWN_IDLE_TIMER}"
+    if [[ "$${ENABLE_AUTO_SHUTDOWN}" = "false" ]]; then
+        INSTALL_OPTS="$${INSTALL_OPTS} --disabled"
+    fi
+    
+    retry /tmp/idleShutdown/Install-Idle-Shutdown.sh $${INSTALL_OPTS}
+
+    exitCode=$?
+    if [[ $exitCode -ne 0 ]]; then
+        log "--> Failed to install idle shutdown."
+        exit 1
     fi
 }
 
@@ -200,6 +246,8 @@ systemctl set-default graphical.target
 join_domain
 
 install_pcoip_agent
+
+install_idle_shutdown
 
 log "--> Installation is completed !!!"
 

--- a/modules/gcp/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-startup.sh.tmpl
@@ -15,6 +15,7 @@ PCOIP_AGENT_REPO_URL=${pcoip_agent_repo_url}
 
 ENABLE_AUTO_SHUTDOWN=${enable_workstation_idle_shutdown}
 AUTO_SHUTDOWN_IDLE_TIMER=${minutes_idle_before_shutdown}
+CPU_POLLING_INTERVAL=${minutes_cpu_polling_interval}
 
 log() {
     local message="$1"
@@ -122,8 +123,9 @@ install_idle_shutdown() {
 
     retry wget "https://raw.githubusercontent.com/teradici/deploy/master/remote-workstations/new-agent-vm/Install-Idle-Shutdown.sh" -O /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh
     
-    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && sudo chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
+    awk '{ sub("\r$", ""); print }' /tmp/idleShutdown/Install-Idle-Shutdown-raw.sh > /tmp/idleShutdown/Install-Idle-Shutdown.sh && chmod +x /tmp/idleShutdown/Install-Idle-Shutdown.sh
 
+    log "--> Setting auto shutdown idle timer to $${AUTO_SHUTDOWN_IDLE_TIMER} minutes"
     INSTALL_OPTS="--idle-timer $${AUTO_SHUTDOWN_IDLE_TIMER}"
     if [[ "$${ENABLE_AUTO_SHUTDOWN}" = "false" ]]; then
         INSTALL_OPTS="$${INSTALL_OPTS} --disabled"
@@ -135,6 +137,12 @@ install_idle_shutdown() {
     if [[ $exitCode -ne 0 ]]; then
         log "--> Failed to install idle shutdown."
         exit 1
+    fi
+
+    if [[ $CPU_POLLING_INTERVAL -ne 15 ]]; then
+        log "--> Setting CPU polling interval to $${CPU_POLLING_INTERVAL} minutes"
+        sed -i "s/OnUnitActiveSec=15min/OnUnitActiveSec=$${CPU_POLLING_INTERVAL}min/g" /etc/systemd/system/CAMIdleShutdown.timer.d/CAMIdleShutdown.conf
+        systemctl daemon-reload
     fi
 }
 

--- a/modules/gcp/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-startup.sh.tmpl
@@ -32,7 +32,7 @@ retry() {
 
             log "--> Failed to run command. $${@}"
             log "--> Retries left... $(( $max_retries - $retries ))"
-            ((n++))
+            ((retries++))
             sleep 10;
         }
     done

--- a/modules/gcp/centos-std/main.tf
+++ b/modules/gcp/centos-std/main.tf
@@ -35,6 +35,7 @@ resource "google_storage_bucket_object" "centos-std-startup-script" {
 
       enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
       minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
+      minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
     }
   )
 }

--- a/modules/gcp/centos-std/main.tf
+++ b/modules/gcp/centos-std/main.tf
@@ -32,6 +32,9 @@ resource "google_storage_bucket_object" "centos-std-startup-script" {
       ad_service_account_password = var.ad_service_account_password,
       pcoip_agent_repo_pubkey_url = var.pcoip_agent_repo_pubkey_url,
       pcoip_agent_repo_url        = var.pcoip_agent_repo_url,
+
+      enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
+      minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
     }
   )
 }

--- a/modules/gcp/centos-std/vars.tf
+++ b/modules/gcp/centos-std/vars.tf
@@ -75,6 +75,11 @@ variable "minutes_idle_before_shutdown" {
   default     = 240
 }
 
+variable "minutes_cpu_polling_interval" {
+  description = "Polling interval for checking CPU utilization to determine if machine is idle, must be between 1 and 60"
+  default     = 15
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/centos-std/vars.tf
+++ b/modules/gcp/centos-std/vars.tf
@@ -65,6 +65,16 @@ variable "enable_public_ip" {
   default     = false
 }
 
+variable "enable_workstation_idle_shutdown" {
+  description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
+  default     = true
+}
+
+variable "minutes_idle_before_shutdown" {
+  description = "Minimum idle time for Workstations before auto idle shutdown, must be between 5 and 10000"
+  default     = 240
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/win-gfx/main.tf
+++ b/modules/gcp/win-gfx/main.tf
@@ -36,6 +36,7 @@ resource "google_storage_bucket_object" "win-gfx-startup-script" {
       
       enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
       minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
+      minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
     }
   )
 }

--- a/modules/gcp/win-gfx/main.tf
+++ b/modules/gcp/win-gfx/main.tf
@@ -33,6 +33,9 @@ resource "google_storage_bucket_object" "win-gfx-startup-script" {
       ad_service_account_password = var.ad_service_account_password,
       pcoip_agent_location_url    = var.pcoip_agent_location_url,
       pcoip_agent_filename        = var.pcoip_agent_filename,
+      
+      enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
+      minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
     }
   )
 }

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -60,6 +60,16 @@ variable "enable_public_ip" {
   default     = false
 }
 
+variable "enable_workstation_idle_shutdown" {
+  description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
+  default     = true
+}
+
+variable "minutes_idle_before_shutdown" {
+  description = "Minimum idle time for Workstations before auto idle shutdown, must be between 5 and 10000"
+  default     = 240
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -70,6 +70,11 @@ variable "minutes_idle_before_shutdown" {
   default     = 240
 }
 
+variable "minutes_cpu_polling_interval" {
+  description = "Polling interval for checking CPU utilization to determine if machine is idle, must be between 1 and 60"
+  default     = 15
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -23,6 +23,7 @@ $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
 $AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
+$CPU_POLLING_INTERVAL     = ${minutes_cpu_polling_interval}
 
 $global:restart = $false
 
@@ -238,14 +239,16 @@ function Install-Idle-Shutdown {
         exit 1
     }
 
-    $idleTimerRegKeyPath = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
-    $idleTimerRegKeyName = "MinutesIdleBeforeShutdown"
+    $idleShutdownRegKeyPath       = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
+    $idleTimerRegKeyName          = "MinutesIdleBeforeShutdown"
+    $cpuPollingIntervalRegKeyName = "PollingIntervalMinutes"
 
-    if (!(Test-Path $idleTimerRegKeyPath)) {
+    if (!(Test-Path $idleShutdownRegKeyPath)) {
         New-Item -Path $idleTimerRegKeyPath -Force
     }
 
-    New-ItemProperty -Path $idleTimerRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+    New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+    New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force
 
     if (!($ENABLE_AUTO_SHUTDOWN)) {
         Set-Service CAMIdleShutdown -StartupType "Disabled"

--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -21,6 +21,9 @@ $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
 $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
+$ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
+$AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
+
 $global:restart = $false
 
 # Retry function, defaults to trying for 5 minutes with 10 seconds intervals
@@ -218,6 +221,37 @@ function PCoIP-Agent-Register {
     "PCoIP Agent Registered Successfully"
 }
 
+function Install-Idle-Shutdown {
+    "################################################################"
+    "Installing Idle Shutdown..."
+    "################################################################"
+
+    $serviceName = "CAMIdleShutdown"
+    $path = "C:\Program Files\Teradici\PCoIP Agent\bin"
+    $is64 = $true
+
+    cd $path
+
+    $ret = .\IdleShutdownAgent.exe -install
+    if( !$? ) {
+        "ERROR: failed to install idle shutdown."
+        exit 1
+    }
+
+    $idleTimerRegKeyPath = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
+    $idleTimerRegKeyName = "MinutesIdleBeforeShutdown"
+
+    if (!(Test-Path $idleTimerRegKeyPath)) {
+        New-Item -Path $idleTimerRegKeyPath -Force
+    }
+
+    New-ItemProperty -Path $idleTimerRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+
+    if (!($ENABLE_AUTO_SHUTDOWN)) {
+        Set-Service CAMIdleShutdown -StartupType "Disabled"
+    }
+}
+
 function Join-Domain {
     "################################################################"
     "Join Domain"
@@ -334,6 +368,8 @@ Nvidia-Install
 PCoIP-Agent-Install
 
 PCoIP-Agent-Register
+
+Install-Idle-Shutdown
 
 Join-Domain
 

--- a/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-startup.ps1.tmpl
@@ -21,7 +21,7 @@ $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
 $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
-$ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
+$ENABLE_AUTO_SHUTDOWN     = [System.Convert]::ToBoolean("${enable_workstation_idle_shutdown}")
 $AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
 $CPU_POLLING_INTERVAL     = ${minutes_cpu_polling_interval}
 
@@ -226,13 +226,10 @@ function Install-Idle-Shutdown {
     "################################################################"
     "Installing Idle Shutdown..."
     "################################################################"
-
-    $serviceName = "CAMIdleShutdown"
     $path = "C:\Program Files\Teradici\PCoIP Agent\bin"
-    $is64 = $true
-
     cd $path
 
+    # Install service and check for success
     $ret = .\IdleShutdownAgent.exe -install
     if( !$? ) {
         "ERROR: failed to install idle shutdown."
@@ -246,12 +243,26 @@ function Install-Idle-Shutdown {
     if (!(Test-Path $idleShutdownRegKeyPath)) {
         New-Item -Path $idleTimerRegKeyPath -Force
     }
-
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force
 
-    if (!($ENABLE_AUTO_SHUTDOWN)) {
-        Set-Service CAMIdleShutdown -StartupType "Disabled"
+    if (!$ENABLE_AUTO_SHUTDOWN) {
+        $svc = Get-Service -Name "CAMIdleShutdown"
+        "Attempting to disable CAMIdleShutdown..."
+        try {
+            if ($svc.Status -ne "Stopped") {
+                Start-Sleep -s 15
+                $svc.Stop()
+                $svc.WaitForStatus("Stopped", 180)
+            }
+            Set-Service -InputObject $svc -StartupType "Disabled"
+            $status = if ($?) { "succeeded" } else { "failed" }
+            $msg = "Disabling CAMIdleShutdown {0}." -f $status
+            "$msg"
+        }
+        catch {
+            throw "ERROR: Failed to disable CAMIdleShutdown service."
+        }
     }
 }
 

--- a/modules/gcp/win-std/main.tf
+++ b/modules/gcp/win-std/main.tf
@@ -35,6 +35,7 @@ resource "google_storage_bucket_object" "win-std-startup-script" {
 
       enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
       minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
+      minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval,
     }
   )
 }

--- a/modules/gcp/win-std/main.tf
+++ b/modules/gcp/win-std/main.tf
@@ -32,6 +32,9 @@ resource "google_storage_bucket_object" "win-std-startup-script" {
       ad_service_account_password = var.ad_service_account_password,
       pcoip_agent_location_url    = var.pcoip_agent_location_url,
       pcoip_agent_filename        = var.pcoip_agent_filename,
+
+      enable_workstation_idle_shutdown = var.enable_workstation_idle_shutdown,
+      minutes_idle_before_shutdown     = var.minutes_idle_before_shutdown,
     }
   )
 }

--- a/modules/gcp/win-std/vars.tf
+++ b/modules/gcp/win-std/vars.tf
@@ -60,6 +60,16 @@ variable "enable_public_ip" {
   default     = false
 }
 
+variable "enable_workstation_idle_shutdown" {
+  description = "Enable Cloud Access Manager auto idle shutdown for Workstations"
+  default     = true
+}
+
+variable "minutes_idle_before_shutdown" {
+  description = "Minimum idle time for Workstations before auto idle shutdown, must be between 5 and 10000"
+  default     = 240
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/win-std/vars.tf
+++ b/modules/gcp/win-std/vars.tf
@@ -70,6 +70,11 @@ variable "minutes_idle_before_shutdown" {
   default     = 240
 }
 
+variable "minutes_cpu_polling_interval" {
+  description = "Polling interval for checking CPU utilization to determine if machine is idle, must be between 1 and 60"
+  default     = 15
+}
+
 variable "network_tags" {
   description = "Tags to be applied to the Workstation"
   type        = list(string)

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -20,6 +20,9 @@ $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
 $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
+$ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
+$AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
+
 $global:restart = $false
 
 # Retry function, defaults to trying for 5 minutes with 10 seconds intervals
@@ -175,6 +178,37 @@ function PCoIP-Agent-Register {
     "PCoIP Agent Registered Successfully"
 }
 
+function Install-Idle-Shutdown {
+    "################################################################"
+    "Installing Idle Shutdown..."
+    "################################################################"
+
+    $serviceName = "CAMIdleShutdown"
+    $path = "C:\Program Files\Teradici\PCoIP Agent\bin"
+    $is64 = $true
+
+    cd $path
+
+    $ret = .\IdleShutdownAgent.exe -install
+    if( !$? ) {
+        "ERROR: failed to install idle shutdown."
+        exit 1
+    }
+
+    $idleTimerRegKeyPath = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
+    $idleTimerRegKeyName = "MinutesIdleBeforeShutdown"
+
+    if (!(Test-Path $idleTimerRegKeyPath)) {
+        New-Item -Path $idleTimerRegKeyPath -Force
+    }
+
+    New-ItemProperty -Path $idleTimerRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+
+    if (!($ENABLE_AUTO_SHUTDOWN)) {
+        Set-Service CAMIdleShutdown -StartupType "Disabled"
+    }
+}
+
 function Join-Domain {
     "################################################################"
     "Join Domain"
@@ -289,6 +323,8 @@ net user Administrator $DATA."admin_password" /active:yes
 PCoIP-Agent-Install
 
 PCoIP-Agent-Register
+
+Install-Idle-Shutdown
 
 Join-Domain
 

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -22,6 +22,7 @@ $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
 $ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
 $AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
+$CPU_POLLING_INTERVAL     = ${minutes_cpu_polling_interval}
 
 $global:restart = $false
 
@@ -195,14 +196,16 @@ function Install-Idle-Shutdown {
         exit 1
     }
 
-    $idleTimerRegKeyPath = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
-    $idleTimerRegKeyName = "MinutesIdleBeforeShutdown"
+    $idleShutdownRegKeyPath       = "HKLM:SOFTWARE\Teradici\CAMShutdownIdleMachineAgent"
+    $idleTimerRegKeyName          = "MinutesIdleBeforeShutdown"
+    $cpuPollingIntervalRegKeyName = "PollingIntervalMinutes"
 
-    if (!(Test-Path $idleTimerRegKeyPath)) {
+    if (!(Test-Path $idleShutdownRegKeyPath)) {
         New-Item -Path $idleTimerRegKeyPath -Force
     }
 
-    New-ItemProperty -Path $idleTimerRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+    New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
+    New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force
 
     if (!($ENABLE_AUTO_SHUTDOWN)) {
         Set-Service CAMIdleShutdown -StartupType "Disabled"

--- a/modules/gcp/win-std/win-std-startup.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-startup.ps1.tmpl
@@ -20,7 +20,7 @@ $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
 $DATA.Add("admin_password", "${admin_password}")
 $DATA.Add("ad_service_account_password", "${ad_service_account_password}")
 
-$ENABLE_AUTO_SHUTDOWN     = "${enable_workstation_idle_shutdown}"
+$ENABLE_AUTO_SHUTDOWN     = [System.Convert]::ToBoolean("${enable_workstation_idle_shutdown}")
 $AUTO_SHUTDOWN_IDLE_TIMER = ${minutes_idle_before_shutdown}
 $CPU_POLLING_INTERVAL     = ${minutes_cpu_polling_interval}
 
@@ -183,13 +183,10 @@ function Install-Idle-Shutdown {
     "################################################################"
     "Installing Idle Shutdown..."
     "################################################################"
-
-    $serviceName = "CAMIdleShutdown"
     $path = "C:\Program Files\Teradici\PCoIP Agent\bin"
-    $is64 = $true
-
     cd $path
 
+    # Install service and check for success
     $ret = .\IdleShutdownAgent.exe -install
     if( !$? ) {
         "ERROR: failed to install idle shutdown."
@@ -203,12 +200,26 @@ function Install-Idle-Shutdown {
     if (!(Test-Path $idleShutdownRegKeyPath)) {
         New-Item -Path $idleTimerRegKeyPath -Force
     }
-
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force
 
-    if (!($ENABLE_AUTO_SHUTDOWN)) {
-        Set-Service CAMIdleShutdown -StartupType "Disabled"
+    if (!$ENABLE_AUTO_SHUTDOWN) {
+        $svc = Get-Service -Name "CAMIdleShutdown"
+        "Attempting to disable CAMIdleShutdown..."
+        try {
+            if ($svc.Status -ne "Stopped") {
+                Start-Sleep -s 15
+                $svc.Stop()
+                $svc.WaitForStatus("Stopped", 180)
+            }
+            Set-Service -InputObject $svc -StartupType "Disabled"
+            $status = if ($?) { "succeeded" } else { "failed" }
+            $msg = "Disabling CAMIdleShutdown {0}." -f $status
+            "$msg"
+        }
+        catch {
+            throw "ERROR: Failed to disable CAMIdleShutdown service."
+        }
     }
 }
 


### PR DESCRIPTION
All workstations deployed by Terraform now has auto idle shutdown enabled
by default. The default settings for idle shutdown is <enabled>, idle timer
at <240> minutes, CPU idle threshold at <20>%, and CPU polling interval
at <15> minutes. These default values were used to be in line with the idle 
shutdown settings for workstations deployed by CAM.