### PR TITLE
GCP: use Terraform self-signed TLS certificate

### DIFF
--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -36,9 +36,9 @@ cac_instance_count_list = []
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
 # cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200218"
+# ssl_key  = "/path/to/privkey.pem"
+# ssl_cert = "/path/to/fullchain.pem"
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
-ssl_key  = "/path/to/privkey.pem"
-ssl_cert = "/path/to/fullchain.pem"
 
 win_gfx_instance_count = 0
 # win_gfx_machine_type = "n1-standard-4"


### PR DESCRIPTION
The default for multi-region GCP deployment has been changed to use
Terraform's self-signed TLS certificate. This makes it easier for users
to deploy multi-region since users no longer have to generate
self-signed certs outside of Terraform. The option for users to specify
their own certs is available inside of terraform.tfvars.

Signed-off-by: Edwin Pau <epau@teradici.com>