### PR TITLE
AWS: update win_gfx workstations to use base OS

### DIFF
--- a/deployments/aws/lb-connectors/terraform.tfvars.sample
+++ b/deployments/aws/lb-connectors/terraform.tfvars.sample
@@ -54,14 +54,14 @@ admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 win_gfx_instance_count = 0
 # win_gfx_instance_type = "g4dn.xlarge"
 # win_gfx_disk_size_gb  = 50
-# win_gfx_ami_owner     = "aws-marketplace"
-# win_gfx_ami_name      = "nvOffer-grid9.2-nv-windows-server-2019-QvWS-432.08-v201911180035*"
+# win_std_ami_owner     = "amazon"
+# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.03.18"
 
 win_std_instance_count = 0
 # win_std_instance_type = "t2.xlarge"
 # win_std_disk_size_gb  = 50
 # win_std_ami_owner     = "amazon"
-# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.03.11"
+# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.03.18"
 
 # REQUIRED: ensure the AWS account used has subscribed to the "CentOS 7 (x86_64)
 # - with Updates HVM" image using the AWS dashboard at

--- a/deployments/aws/lb-connectors/vars.tf
+++ b/deployments/aws/lb-connectors/vars.tf
@@ -67,7 +67,7 @@ variable "dc_ami_owner" {
 
 variable "dc_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "Windows_Server-2019-English-Full-Base-2020.03.11"
+  default     = "Windows_Server-2019-English-Full-Base-2020.03.18"
 }
 
 variable "domain_name" {
@@ -200,12 +200,12 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_ami_owner" {
   description = "Owner of AMI for the Windows Graphics Workstations"
-  default     = "aws-marketplace"
+  default     = "amazon"
 }
 
 variable "win_gfx_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "nvOffer-grid9.2-nv-windows-server-2019-QvWS-432.08-v201911180035*"
+  default     = "Windows_Server-2019-English-Full-Base-2020.03.18"
 }
 
 variable "win_std_instance_count" {
@@ -230,7 +230,7 @@ variable "win_std_ami_owner" {
 
 variable "win_std_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "Windows_Server-2019-English-Full-Base-2020.03.11"
+  default     = "Windows_Server-2019-English-Full-Base-2020.03.18"
 }
 
 variable "centos_gfx_instance_count" {

--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -34,7 +34,7 @@ win_gfx_instance_count = 0
 # win_gfx_instance_type = "g4dn.xlarge"
 # win_gfx_disk_size_gb  = 50
 # win_std_ami_owner     = "amazon"
-# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.02.12"
+# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.03.18"
 
 win_std_instance_count = 0
 # win_std_instance_type = "t2.xlarge"

--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -33,8 +33,8 @@ admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 win_gfx_instance_count = 0
 # win_gfx_instance_type = "g4dn.xlarge"
 # win_gfx_disk_size_gb  = 50
-# win_gfx_ami_owner     = "aws-marketplace"
-# win_gfx_ami_name      = "nvOffer-grid9.2-nv-windows-server-2019-QvWS-432.08-v201911180035*"
+# win_std_ami_owner     = "amazon"
+# win_std_ami_name      = "Windows_Server-2019-English-Full-Base-2020.02.12"
 
 win_std_instance_count = 0
 # win_std_instance_type = "t2.xlarge"

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -190,7 +190,7 @@ variable "win_gfx_ami_owner" {
 
 variable "win_gfx_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "Windows_Server-2019-English-Full-Base-2020.02.12"
+  default     = "Windows_Server-2019-English-Full-Base-2020.03.18"
 }
 
 variable "win_std_instance_count" {

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -185,12 +185,12 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_ami_owner" {
   description = "Owner of AMI for the Windows Graphics Workstations"
-  default     = "aws-marketplace"
+  default     = "amazon"
 }
 
 variable "win_gfx_ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "nvOffer-grid9.2-nv-windows-server-2019-QvWS-432.08-v201911180035*"
+  default     = "Windows_Server-2019-English-Full-Base-2020.02.12"
 }
 
 variable "win_std_instance_count" {

--- a/docs/README-aws.md
+++ b/docs/README-aws.md
@@ -19,8 +19,7 @@ With a new AWS account:
 aws_access_key_id = <your_id>
 aws_secret_access_key = <your_key>
 ```
-- in the AWS marketplace portal, visit the Product Overview pages of AMI images that will be used by Terraform scripts. Click on the "Continue to Subscribe" button in the top-right corner of the webpage and subscribe by accepting the terms. The required subscriptions depend on which workstation is to be deployed:
-    - Windows Graphics workstation: https://aws.amazon.com/marketplace/pp/B07TS3S3ZH
+- in the AWS marketplace portal, visit the Product Overview pages of AMI images that will be used by Terraform scripts. Click on the "Continue to Subscribe" button in the top-right corner of the webpage and subscribe by accepting the terms. Note that only CentOS Standard or Graphics workstations require subscriptions to the AMI images. Visit the following link to subscribe prior to deployment:
     - CentOS Standard or Graphics workstation: https://aws.amazon.com/marketplace/pp/B07TV59ZQK
 - (Optional) For better security, create an AWS KMS Customer Managed Symmetric Customer Master Key (CMK) to encrypt secrets.  Please refer to https://docs.aws.amazon.com/kms/latest/developerguide/create-keys.html for instructions to create CMKs.
 

--- a/modules/aws/win-gfx/main.tf
+++ b/modules/aws/win-gfx/main.tf
@@ -26,6 +26,8 @@ resource "aws_s3_bucket_object" "win-gfx-startup-script" {
     {
       customer_master_key_id      = var.customer_master_key_id,
       pcoip_registration_code     = var.pcoip_registration_code,
+      nvidia_driver_url           = var.nvidia_driver_url,
+      nvidia_driver_filename      = var.nvidia_driver_filename,
       domain_name                 = var.domain_name,
       admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,

--- a/modules/aws/win-gfx/vars.tf
+++ b/modules/aws/win-gfx/vars.tf
@@ -74,17 +74,27 @@ variable "disk_size_gb" {
 
 variable "ami_owner" {
   description = "Owner of AMI"
-  default     = "aws-marketplace"
+  default     = "amazon"
 }
 
 variable "ami_name" {
   description = "Name of the Windows AMI to create workstation from"
-  default     = "nvOffer-grid9.2-nv-windows-server-2019-QvWS-*"
+  default     = "Windows_Server-2019-English-Full-Base-*"
 }
 
 variable "admin_password" {
   description = "Password for the Administrator of the Workstation"
   type        = string
+}
+
+variable "nvidia_driver_url" {
+  description = "URL of NVIDIA GRID driver"
+  default     = "https://s3.amazonaws.com/ec2-windows-nvidia-drivers/g4/grid-10.0/"
+}
+
+variable "nvidia_driver_filename" {
+  description = "Filename of NVIDIA GRID driver"
+  default     = "441.66_grid_win10_64bit_international_whql.exe"
 }
 
 variable "pcoip_agent_location_url" {

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -4,8 +4,13 @@
 # LICENSE file in the root directory of this source tree.
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
+$NVIDIA_DIR = "C:\Program Files\NVIDIA Corporation\NVSMI"
+
 $PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
 $PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
+
+$NVIDIA_DRIVER_URL      = "${nvidia_driver_url}"
+$NVIDIA_DRIVER_FILENAME = "${nvidia_driver_filename}"
 
 $DATA = New-Object "System.Collections.Generic.Dictionary[[String],[String]]"
 $DATA.Add("pcoip_registration_code", "${pcoip_registration_code}")
@@ -58,6 +63,50 @@ function Retry([scriptblock]$Action, $Interval = 10, $Attempts = 30) {
     Write-Information "Attempt $Attempt failed. Retry in $Interval seconds..." -InformationAction Continue
     Start-Sleep -Seconds $Interval
   }
+}
+
+function Nvidia-is-Installed {
+    if (!(test-path $NVIDIA_DIR)) {
+        return $false
+    }
+
+    cd $NVIDIA_DIR
+    & .\nvidia-smi.exe
+    return $?
+    return $false
+}
+
+function Nvidia-Install {
+    "################################################################"
+    "Install NVIDIA GRID Driver"
+    "################################################################"
+
+    if (Nvidia-is-Installed) {
+        "NVIDIA driver already installed."
+        return
+    }
+
+    mkdir 'C:\Nvidia'
+    $driverDirectory = "C:\Nvidia"
+
+    $nvidiaInstallerUrl = $NVIDIA_DRIVER_URL + $NVIDIA_DRIVER_FILENAME
+    $destFile = $driverDirectory + "\" + $NVIDIA_DRIVER_FILENAME
+    $wc = New-Object System.Net.WebClient
+
+    "Downloading NVIDIA GRID Driver from $NVIDIA_DRIVER_URL..."
+    Retry -Action {$wc.DownloadFile($nvidiaInstallerUrl, $destFile)}
+    "File Downloaded: $NVIDIA_DRIVER_FILENAME"
+
+    "Installing NVIDIA GRID Driver..."
+    $ret = Start-Process -FilePath $destFile -ArgumentList "/s /noeula /noreboot" -PassThru -Wait
+
+    if (!(Nvidia-is-Installed)) {
+        "ERROR: Failed to install NVIDIA GRID driver."
+        exit 1
+    }
+
+    "NVIDIA GRID Driver installed successfully."
+    $global:restart = $true
 }
 
 function PCoIP-Agent-is-Installed {
@@ -271,6 +320,8 @@ if ([string]::IsNullOrWhiteSpace("${customer_master_key_id}")) {
 net user Administrator $DATA."admin_password" /active:yes
 
 [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.SecurityProtocolType]::Tls12
+
+Nvidia-Install
 
 PCoIP-Agent-Install
 

--- a/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
+++ b/modules/aws/win-gfx/win-gfx-startup.ps1.tmpl
@@ -73,7 +73,6 @@ function Nvidia-is-Installed {
     cd $NVIDIA_DIR
     & .\nvidia-smi.exe
     return $?
-    return $false
 }
 
 function Nvidia-Install {


### PR DESCRIPTION
Instead of using subscription-required Windows OS for Windows
graphics workstations, it now uses the same base OS as standard
Windows workstations and installs the required Nvidia graphics
drivers manually as part of the startup script.

Signed-off-by: Edwin-Pau <epau@teradici.com>