### PR TITLE
GCP: update external health check endpoint for CACv2

### DIFF
--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -157,7 +157,7 @@ variable "cac_admin_ssh_pub_key_file" {
 variable "cac_health_check" {
   description = "Health check configuration for Cloud Access Connector"
   default = {
-    path         = "/CloudAccessManager/"
+    path         = "/pcoip-broker/xml"
     port         = 443
     interval_sec = 5
     timeout_sec  = 5


### PR DESCRIPTION
A new endpoint /pcoip-broker/xml/ is used instead of the old endpoint
/CloudAccessManager/ for unauthenticated external health checks. The
new endpoint is used before the old one becomes deprecated.

Signed-off-by: Edwin-Pau <epau@teradici.com>