### PR TITLE
GCP: fix quickstart deployment (write tfvars)

### DIFF
--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -253,6 +253,11 @@ def tf_vars_create(ref_file_path, tfvar_file_path, settings):
 
     with open(ref_file_path, 'r') as ref_file, open(tfvar_file_path, 'w') as out_file:
         for line in ref_file:
+            # Append the crypto key path to kms_cryptokey_id line since it is commented out in ref_file
+            if '# kms_cryptokey_id' in line:
+                out_file.write('{} = \"{}\"'.format('kms_cryptokey_id', settings['kms_cryptokey_id']))
+                continue
+
             # Comments and blank lines are unchanged
             if line[0] in ('#', '\n'):
                 out_file.write(line)


### PR DESCRIPTION
A recent commit from encryption/decryption script changed the default
of the kms_cryptokey_id line inside of terraform.tfvars to be a comment
instead. This caused quickstart deployment scripts to not use encryption
since it did not detect a kms_cryptokey_id variable, which caused
the deployment to fail.

The fix explicitly checks for this line and adds it to the quickstart
script first so that the terraform.tfvars is properly created.

Signed-off-by: Edwin-Pau <epau@teradici.com>