### PR TITLE
Update documentation for Windows path separator

### DIFF
--- a/deployments/aws/lb-connectors/terraform.tfvars.sample
+++ b/deployments/aws/lb-connectors/terraform.tfvars.sample
@@ -1,4 +1,6 @@
 # Commented out lines represents defaults that can be changed
+# On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
+# Example: aws_credentials_file = "C:/path/to/aws_key"
 
 # Path to an AWS Crentials File. Please see
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html

--- a/deployments/aws/single-connector/terraform.tfvars.sample
+++ b/deployments/aws/single-connector/terraform.tfvars.sample
@@ -1,4 +1,6 @@
 # Commented out lines represents defaults that can be changed
+# On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
+# Example: aws_credentials_file = "C:/path/to/aws_key"
 
 # Path to an AWS Crentials File. Please see
 # https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-files.html

--- a/deployments/gcp/dc-only/terraform.tfvars.sample
+++ b/deployments/gcp/dc-only/terraform.tfvars.sample
@@ -1,4 +1,7 @@
 # Commented out lines represents defaults that can be changed
+# On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
+# Example: gcp_credentials_file = "C:/path/to/cred.json"
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -1,4 +1,7 @@
 # Commented out lines represents defaults that can be changed
+# On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
+# Example: gcp_credentials_file = "C:/path/to/cred.json"
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -1,4 +1,7 @@
 # Commented out lines represents defaults that can be changed
+# On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
+# Example: gcp_credentials_file = "C:/path/to/cred.json"
+
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"

--- a/docs/README-aws.md
+++ b/docs/README-aws.md
@@ -45,6 +45,10 @@ The following command can be used to decrypt the ciphertext:
 ### Customizing terraform.tfvars
 terraform.tfvars is the file in which a user specify variables for a deployment. In each deployment, there is a ```terraform.tfvars.sample``` file showing the required variables that a user must provide, along with other commonly used but optional variables. Uncommented lines show required variables, while commented lines show optional variables with their default or sample values. A complete list of available variables are described in the variable definition file ```vars.tf``` of the deployment.
 
+Note that all path variables in terraform.tfvars depend on the host platform: 
+- On Linux systems, the forward slash / is used as the path segment separator. ```aws_credentials_file = "/path/to/aws_key"```
+- On Windows systems, the default Windows backslash \ separator must be changed to forward slash as the path segment separator. ```aws_credentials_file = "C:/path/to/aws_key"```
+
 Save ```terraform.tfvars.sample``` as ```terraform.tfvars``` in the same directory, and fill out the required and optional variables.
 
 If secrets are KMS CMK encrypted, fill in the ```customer_master_key_id``` variable with the customer master key id used to encode the secrets, then paste the base64-encoded ciphertext for the following variables:

--- a/docs/README-gcp.md
+++ b/docs/README-gcp.md
@@ -58,6 +58,10 @@ The default mode is encryption; to decrypt the secrets back to plaintext, use th
 ### Customizing terraform.tfvars
 terraform.tfvars is the file in which a user specify variables for a deployment. In each deployment, there is a ```terraform.tfvars.sample``` file showing the required variables that a user must provide, along with other commonly used but optional variables. Uncommented lines show required variables, while commented lines show optional variables with their default or sample values. A complete list of available variables are described in the variable definition file ```vars.tf``` of the deployment.
 
+Note that all path variables in terraform.tfvars depend on the host platform: 
+- On Linux systems, the forward slash / is used as the path segment separator. ```gcp_credentials_file = "/path/to/cred.json"```
+- On Windows systems, the default Windows backslash \ separator must be changed to forward slash as the path segment separator. ```gcp_credentials_file = "C:/path/to/cred.json"```
+
 Save ```terraform.tfvars.sample``` as ```terraform.tfvars``` in the same directory, and fill out the required and optional variables.
 
 If secrets are KMS-encrypted, fill in the ```kms_cryptokey_id``` variable with the crypto key used to encode the secrets, then paste the base64-encoded ciphertext for the following variables:


### PR DESCRIPTION
Documentation and sample tfvars files were updated with information
on using the forward slash path separator instead of backslash
for Windows systems.

Signed-off-by: Edwin-Pau <epau@teradici.com>