### PR TITLE
GCP: fix quickstart get_user API call

### DIFF
--- a/quickstart/cam.py
+++ b/quickstart/cam.py
@@ -112,7 +112,7 @@ class CloudAccessManager:
         resp.raise_for_status()
         resp = resp.json()
 
-        return resp['data'][0] if resp['total'] >= 1 else None
+        return resp['data'][0] if len(resp.get('data', [])) >= 1 else None
 
     def machines_get(self, deployment):
         resp = requests.get(


### PR DESCRIPTION
Fixed an issue when the script was stuck in the loop due to a bug
in the CAM API response. Instead of using the 'total' key to determine
if data exists for a response, it has now been changed to use the length
of the 'data' array.

Signed-off-by: Edwin-Pau <epau@teradici.com>