### PR TITLE
AWS: update Nvidia GRID driver

### DIFF
--- a/modules/aws/win-gfx/vars.tf
+++ b/modules/aws/win-gfx/vars.tf
@@ -89,12 +89,12 @@ variable "admin_password" {
 
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
-  default     = "https://s3.amazonaws.com/ec2-windows-nvidia-drivers/g4/grid-10.0/"
+  default     = "https://s3.amazonaws.com/ec2-windows-nvidia-drivers/g4/grid-10.1/"
 }
 
 variable "nvidia_driver_filename" {
   description = "Filename of NVIDIA GRID driver"
-  default     = "441.66_grid_win10_64bit_international_whql.exe"
+  default     = "442.49_grid_win10_64bit_international.exe"
 }
 
 variable "pcoip_agent_location_url" {


### PR DESCRIPTION
Nvidia GRID driver for AWS win-gfx has been updated to 442.49.

Signed-off-by: Edwin-Pau <epau@teradici.com>