### PR TITLE
AWS: Add prefix to IAM resources

### DIFF
--- a/modules/aws/cac/main.tf
+++ b/modules/aws/cac/main.tf
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy-doc" {
 resource "aws_iam_role" "cac-role" {
   count = length(local.instance_info_list) == 0 ? 0 : 1
 
-  name               = "cac_role"
+  name               = "${local.prefix}cac_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -158,7 +158,7 @@ data "aws_iam_policy_document" "cac-policy-doc" {
 resource "aws_iam_role_policy" "cac-role-policy" {
   count = length(local.instance_info_list) == 0 ? 0 : 1
 
-  name = "cac_role_policy"
+  name = "${local.prefix}cac_role_policy"
   role = aws_iam_role.cac-role[0].id
   policy = data.aws_iam_policy_document.cac-policy-doc.json
 }
@@ -166,7 +166,7 @@ resource "aws_iam_role_policy" "cac-role-policy" {
 resource "aws_iam_instance_profile" "cac-instance-profile" {
   count = length(local.instance_info_list) == 0 ? 0 : 1
 
-  name = "cac_instance_profile"
+  name = "${local.prefix}cac_instance_profile"
   role = aws_iam_role.cac-role[0].name
 }
 

--- a/modules/aws/centos-gfx/main.tf
+++ b/modules/aws/centos-gfx/main.tf
@@ -82,7 +82,7 @@ data "aws_kms_key" "encryption-key" {
 resource "aws_iam_role" "centos-gfx-role" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name               = "centos_gfx_role"
+  name               = "${local.prefix}centos_gfx_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -113,7 +113,7 @@ data "aws_iam_policy_document" "centos-gfx-policy-doc" {
 resource "aws_iam_role_policy" "centos-gfx-role-policy" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "centos_gfx_role_policy"
+  name = "${local.prefix}centos_gfx_role_policy"
   role = aws_iam_role.centos-gfx-role[0].id
   policy = data.aws_iam_policy_document.centos-gfx-policy-doc.json
 }
@@ -121,7 +121,7 @@ resource "aws_iam_role_policy" "centos-gfx-role-policy" {
 resource "aws_iam_instance_profile" "centos-gfx-instance-profile" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "centos_gfx_instance_profile"
+  name = "${local.prefix}centos_gfx_instance_profile"
   role = aws_iam_role.centos-gfx-role[0].name
 }
 

--- a/modules/aws/centos-std/main.tf
+++ b/modules/aws/centos-std/main.tf
@@ -81,7 +81,7 @@ data "aws_kms_key" "encryption-key" {
 resource "aws_iam_role" "centos-std-role" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name               = "centos_std_role"
+  name               = "${local.prefix}centos_std_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -112,7 +112,7 @@ data "aws_iam_policy_document" "centos-std-policy-doc" {
 resource "aws_iam_role_policy" "centos-std-role-policy" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "centos_std_role_policy"
+  name = "${local.prefix}centos_std_role_policy"
   role = aws_iam_role.centos-std-role[0].id
   policy = data.aws_iam_policy_document.centos-std-policy-doc.json
 }
@@ -120,7 +120,7 @@ resource "aws_iam_role_policy" "centos-std-role-policy" {
 resource "aws_iam_instance_profile" "centos-std-instance-profile" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "centos_std_instance_profile"
+  name = "${local.prefix}centos_std_instance_profile"
   role = aws_iam_role.centos-std-role[0].name
 }
 

--- a/modules/aws/dc/main.tf
+++ b/modules/aws/dc/main.tf
@@ -104,7 +104,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy-doc" {
 }
 
 resource "aws_iam_role" "dc-role" {
-  name               = "dc_role"
+  name               = "${local.prefix}dc_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -133,13 +133,13 @@ data "aws_iam_policy_document" "dc-policy-doc" {
 }
 
 resource "aws_iam_role_policy" "dc-role-policy" {
-  name = "dc_role_policy"
+  name = "${local.prefix}dc_role_policy"
   role = aws_iam_role.dc-role.id
   policy = data.aws_iam_policy_document.dc-policy-doc.json
 }
 
 resource "aws_iam_instance_profile" "dc-instance-profile" {
-  name = "dc_instance_profile"
+  name = "${local.prefix}dc_instance_profile"
   role = aws_iam_role.dc-role.name
 }
 

--- a/modules/aws/win-gfx/main.tf
+++ b/modules/aws/win-gfx/main.tf
@@ -72,7 +72,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy-doc" {
 resource "aws_iam_role" "win-gfx-role" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name               = "win_gfx_role"
+  name               = "${local.prefix}win_gfx_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -109,7 +109,7 @@ data "aws_iam_policy_document" "win-gfx-policy-doc" {
 resource "aws_iam_role_policy" "win-gfx-role-policy" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "win_gfx_role_policy"
+  name = "${local.prefix}win_gfx_role_policy"
   role = aws_iam_role.win-gfx-role[0].id
   policy = data.aws_iam_policy_document.win-gfx-policy-doc.json
 }
@@ -117,7 +117,7 @@ resource "aws_iam_role_policy" "win-gfx-role-policy" {
 resource "aws_iam_instance_profile" "win-gfx-instance-profile" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "win_gfx_instance_profile"
+  name = "${local.prefix}win_gfx_instance_profile"
   role = aws_iam_role.win-gfx-role[0].name
 }
 

--- a/modules/aws/win-std/main.tf
+++ b/modules/aws/win-std/main.tf
@@ -70,7 +70,7 @@ data "aws_iam_policy_document" "instance-assume-role-policy-doc" {
 resource "aws_iam_role" "win-std-role" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name               = "win_std_role"
+  name               = "${local.prefix}win_std_role"
   assume_role_policy = data.aws_iam_policy_document.instance-assume-role-policy-doc.json
 }
 
@@ -107,7 +107,7 @@ data "aws_iam_policy_document" "win-std-policy-doc" {
 resource "aws_iam_role_policy" "win-std-role-policy" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "win_std_role_policy"
+  name = "${local.prefix}win_std_role_policy"
   role = aws_iam_role.win-std-role[0].id
   policy = data.aws_iam_policy_document.win-std-policy-doc.json
 }
@@ -115,7 +115,7 @@ resource "aws_iam_role_policy" "win-std-role-policy" {
 resource "aws_iam_instance_profile" "win-std-instance-profile" {
   count = tonumber(var.instance_count) == 0 ? 0 : 1
 
-  name = "win_std_instance_profile"
+  name = "${local.prefix}win_std_instance_profile"
   role = aws_iam_role.win-std-role[0].name
 }
 


### PR DESCRIPTION
IAM resources for AWS deployment were missing the prefix string for
the resource names, which prevented these resources from being created
for multiple deployments.

Signed-off-by: Edwin-Pau <epau@teradici.com>