### PR TITLE
AWS: Use allowable AZs (single-connector)

### DIFF
--- a/deployments/aws/single-connector/networking.tf
+++ b/deployments/aws/single-connector/networking.tf
@@ -9,6 +9,11 @@ data "http" "myip" {
   url = "https://ipinfo.io/ip"
 }
 
+data "aws_availability_zones" "available_az" {
+  state                = "available"
+  blacklisted_zone_ids = var.az_id_blacklist
+}
+
 locals {
   myip = "${chomp(data.http.myip.body)}/32"
 }
@@ -24,8 +29,9 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_subnet" "dc-subnet" {
-  cidr_block = var.dc_subnet_cidr
-  vpc_id     = aws_vpc.vpc.id
+  cidr_block        = var.dc_subnet_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available_az.names[0]
 
   tags = {
     Name = "${local.prefix}subnet-dc"
@@ -33,8 +39,9 @@ resource "aws_subnet" "dc-subnet" {
 }
 
 resource "aws_subnet" "cac-subnet" {
-  cidr_block = var.cac_subnet_cidr
-  vpc_id     = aws_vpc.vpc.id
+  cidr_block        = var.cac_subnet_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available_az.names[0]
 
   tags = {
     Name = "${local.prefix}subnet-cac"
@@ -42,8 +49,9 @@ resource "aws_subnet" "cac-subnet" {
 }
 
 resource "aws_subnet" "ws-subnet" {
-  cidr_block = var.ws_subnet_cidr
-  vpc_id     = aws_vpc.vpc.id
+  cidr_block        = var.ws_subnet_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available_az.names[0]
 
   tags = {
     Name = "${local.prefix}subnet-ws"

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -15,6 +15,11 @@ variable "aws_region" {
   default     = "us-west-1"
 }
 
+variable "az_id_blacklist" {
+  description = "List of blacklisted availability zone IDs."
+  default     = ["usw2-az4"]
+}
+
 variable "prefix" {
   description = "Prefix to add to name of new resources. Must be <= 9 characters."
   default     = ""


### PR DESCRIPTION
A data source for availability zones has been added to check and use
the available zones during a deployment. A blacklist of availability
zones has also been added to avoid zones that do not have the required
EC2 instances.

All three subnets have been configured to use the first available and
non-blacklisted availability zone in the region.

Signed-off-by: Edwin-Pau <epau@teradici.com>