### PR TITLE
AWS: Use allowable AZs (lb-connectors)

### DIFF
--- a/deployments/aws/lb-connectors/networking.tf
+++ b/deployments/aws/lb-connectors/networking.tf
@@ -13,6 +13,11 @@ locals {
   myip = "${chomp(data.http.myip.body)}/32"
 }
 
+data "aws_availability_zones" "available_az" {
+  state                = "available"
+  blacklisted_zone_ids = var.az_id_blacklist
+}
+
 resource "aws_vpc" "vpc" {
   cidr_block           = var.vpc_cidr
   enable_dns_support   = true
@@ -24,8 +29,9 @@ resource "aws_vpc" "vpc" {
 }
 
 resource "aws_subnet" "dc-subnet" {
-  cidr_block = var.dc_subnet_cidr
-  vpc_id     = aws_vpc.vpc.id
+  cidr_block        = var.dc_subnet_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available_az.names[0]
 
   tags = {
     Name = "${local.prefix}subnet-dc"
@@ -35,9 +41,9 @@ resource "aws_subnet" "dc-subnet" {
 resource "aws_subnet" "cac-subnets" {
   count = length(var.cac_subnet_cidr_list)
 
-  availability_zone = var.cac_zone_list[count.index]
   cidr_block        = var.cac_subnet_cidr_list[count.index]
   vpc_id            = aws_vpc.vpc.id
+  availability_zone = var.cac_zone_list[count.index]
 
   tags = {
     Name = "${local.prefix}subnet-cac-${var.cac_zone_list[count.index]}"
@@ -45,8 +51,9 @@ resource "aws_subnet" "cac-subnets" {
 }
 
 resource "aws_subnet" "ws-subnet" {
-  cidr_block = var.ws_subnet_cidr
-  vpc_id     = aws_vpc.vpc.id
+  cidr_block        = var.ws_subnet_cidr
+  vpc_id            = aws_vpc.vpc.id
+  availability_zone = data.aws_availability_zones.available_az.names[0]
 
   tags = {
     Name = "${local.prefix}subnet-ws"

--- a/deployments/aws/lb-connectors/vars.tf
+++ b/deployments/aws/lb-connectors/vars.tf
@@ -15,6 +15,13 @@ variable "aws_region" {
   default     = "us-west-1"
 }
 
+# "usw2-az4" failed to provision t2.xlarge EC2 instances in April 2020
+# "use1-az3" failed to provision g4dn.xlarge Windows EC2 instances in April 2020
+variable "az_id_blacklist" {
+  description = "List of blacklisted availability zone IDs."
+  default     = ["usw2-az4", "use1-az3"]
+}
+
 variable "prefix" {
   description = "Prefix to add to name of new resources. Must be <= 9 characters."
   default     = ""


### PR DESCRIPTION
A data source for availability zones has been added so that we can
check and use the available zones during a deployment. A blacklist of
availability zones has also been added to avoid zones that do not have
the required EC2 instances.

The DC and WS subnets have been configured to use the first available
and non-blacklisted availability zone in the region.

Signed-off-by: Edwin-Pau <epau@teradici.com>