### PR TITLE
AWS: Add zone and comment for AZ blacklist

### DIFF
--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -15,9 +15,11 @@ variable "aws_region" {
   default     = "us-west-1"
 }
 
+# "usw2-az4" failed to provision t2.xlarge EC2 instances in April 2020
+# "use1-az3" failed to provision g4dn.xlarge Windows EC2 instances in April 2020
 variable "az_id_blacklist" {
   description = "List of blacklisted availability zone IDs."
-  default     = ["usw2-az4"]
+  default     = ["usw2-az4", "use1-az3"]
 }
 
 variable "prefix" {


### PR DESCRIPTION
Added comments for the availability zone blacklist so we know why we
are avoiding these zones. Added one more zone to avoid since a
g4dn.xlarge Windows EC2 instance failed to provision in April 2020.

Signed-off-by: Edwin-Pau <epau@teradici.com>