### PR TITLE
GCP: Fix kms_cryptokey_id string matching

### DIFF
--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -477,7 +477,7 @@ class Tfvars_Encryptor_GCP:
                 line = line.strip()
 
                 # Append the crypto key path to kms_cryptokey_id line
-                if "kms_cryptokey_id" in line:
+                if "kms_cryptokey_id =" in line:
                     if not self.tfvars_data.get("kms_cryptokey_id"):
                         lines.append("{} = \"{}\"".format("kms_cryptokey_id", self.crypto_key_path))
                     else:


### PR DESCRIPTION
Changed the string matching pattern when writing the new tfvars to only
look for the actual variable assignment line "kms_cryptokey_id =". This
prevents the kms_cryptokey_id from being written multiple times when
the line is only a comment.

Signed-off-by: Edwin-Pau <epau@teradici.com>