### PR TITLE
Add retry logic when installing connector

### DIFF
--- a/modules/aws/cac/cac-startup.sh.tmpl
+++ b/modules/aws/cac/cac-startup.sh.tmpl
@@ -145,36 +145,78 @@ until netcat -vz ${domain_name} 636; do
 done
 
 echo '### Installing Cloud Access Connector ###'
+RETRIES=3
 export CAM_BASE_URI=${cam_url}
 
+# Set pipefail option to return status of the connector install command
+set -o pipefail
+
 if [ -z "${ssl_key}" ]; then
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --insecure \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee -a $INSTALL_LOG
+    while true
+    do
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --insecure \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee -a $INSTALL_LOG
+
+        RC=$?
+        if [ $RC -eq 0 ]
+        then
+            log "--> Successfully installed Cloud Access Connector."
+            break
+        fi
+
+        if [ $RETRIES -eq 0 ]
+        then
+            exit 1
+        fi
+
+        log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+        RETRIES=$((RETRIES-1))
+        sleep 60
+    done
 else
     aws s3 cp s3://${bucket_name}/${ssl_key} $INSTALL_DIR
     aws s3 cp s3://${bucket_name}/${ssl_cert} $INSTALL_DIR
 
-    $INSTALL_DIR/cloud-access-connector install \
-        -t $CAC_TOKEN \
-        --accept-policies \
-        --ssl-key $INSTALL_DIR/${ssl_key} \
-        --ssl-cert $INSTALL_DIR/${ssl_cert} \
-        --sa-user ${ad_service_account_username} \
-        --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-        --domain ${domain_name} \
-        --domain-group "${domain_group}" \
-        --reg-code $PCOIP_REGISTRATION_CODE \
-        --sync-interval 5 \
-        2>&1 | tee -a $INSTALL_LOG
+    while true
+    do
+        $INSTALL_DIR/cloud-access-connector install \
+            -t $CAC_TOKEN \
+            --accept-policies \
+            --ssl-key $INSTALL_DIR/${ssl_key} \
+            --ssl-cert $INSTALL_DIR/${ssl_cert} \
+            --sa-user ${ad_service_account_username} \
+            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+            --domain ${domain_name} \
+            --domain-group "${domain_group}" \
+            --reg-code $PCOIP_REGISTRATION_CODE \
+            --sync-interval 5 \
+            2>&1 | tee -a $INSTALL_LOG
+
+        RC=$?
+        if [ $RC -eq 0 ]
+        then
+            log "--> Successfully installed Cloud Access Connector."
+            break
+        fi
+
+        if [ $RETRIES -eq 0 ]
+        then
+            exit 1
+        fi
+
+        log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+        RETRIES=$((RETRIES-1))
+        sleep 60
+    done
 fi
 
 docker service ls

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -183,6 +183,7 @@ wait_for_dc() {
 
 install_cac() {
     log "--> Installing Cloud Access Connector..."
+    RETRIES=3
     export CAM_BASE_URI=${cam_url}
 
     log "--> Running command: $INSTALL_DIR/cloud-access-connector install"
@@ -192,38 +193,79 @@ install_cac() {
     log "--domain ${domain_name} --domain-group ${domain_group}"
     log "--reg-code <pcoip_registration_code> --sync-interval 5"
 
-    if [ -z "${ssl_key}" ]; then
-        log "--insecure"
+    # Set pipefail option to return status of the connector install command
+    set -o pipefail
 
-        $INSTALL_DIR/cloud-access-connector install \
-            -t $CAC_TOKEN \
-            --accept-policies \
-            --insecure \
-            --sa-user ${ad_service_account_username} \
-            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-            --domain ${domain_name} \
-            --domain-group "${domain_group}" \
-            --reg-code $PCOIP_REGISTRATION_CODE \
-            --sync-interval 5 \
-            2>&1 | tee -a $CAC_INSTALL_LOG
+    if [ -z "${ssl_key}" ]; then
+        while true
+        do
+            log "--insecure"
+
+            $INSTALL_DIR/cloud-access-connector install \
+                -t $CAC_TOKEN \
+                --accept-policies \
+                --insecure \
+                --sa-user ${ad_service_account_username} \
+                --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+                --domain ${domain_name} \
+                --domain-group "${domain_group}" \
+                --reg-code $PCOIP_REGISTRATION_CODE \
+                --sync-interval 5 \
+                2>&1 | tee -a $CAC_INSTALL_LOG
+            
+            RC=$?
+            if [ $RC -eq 0 ]
+            then
+                log "--> Successfully installed Cloud Access Connector."
+                break
+            fi
+
+            if [ $RETRIES -eq 0 ]
+            then
+                exit 1
+            fi
+
+            log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+            RETRIES=$((RETRIES-1))
+            sleep 60
+        done
     else
         gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
         gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
 
-        log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
+        while true
+        do
+            log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
 
-        $INSTALL_DIR/cloud-access-connector install \
-            -t $CAC_TOKEN \
-            --accept-policies \
-            --ssl-key $INSTALL_DIR/${ssl_key} \
-            --ssl-cert $INSTALL_DIR/${ssl_cert} \
-            --sa-user ${ad_service_account_username} \
-            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-            --domain ${domain_name} \
-            --domain-group "${domain_group}" \
-            --reg-code $PCOIP_REGISTRATION_CODE \
-            --sync-interval 5 \
-            2>&1 | tee -a $CAC_INSTALL_LOG
+            $INSTALL_DIR/cloud-access-connector install \
+                -t $CAC_TOKEN \
+                --accept-policies \
+                --ssl-key $INSTALL_DIR/${ssl_key} \
+                --ssl-cert $INSTALL_DIR/${ssl_cert} \
+                --sa-user ${ad_service_account_username} \
+                --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+                --domain ${domain_name} \
+                --domain-group "${domain_group}" \
+                --reg-code $PCOIP_REGISTRATION_CODE \
+                --sync-interval 5 \
+                2>&1 | tee -a $CAC_INSTALL_LOG
+            
+            RC=$?
+            if [ $RC -eq 0 ]
+            then
+                log "--> Successfully installed Cloud Access Connector."
+                break
+            fi
+
+            if [ $RETRIES -eq 0 ]
+            then
+                exit 1
+            fi
+
+            log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+            RETRIES=$((RETRIES-1))
+            sleep 60
+        done
     fi
 }
 

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -183,6 +183,7 @@ wait_for_dc() {
 
 install_cac() {
     log "--> Installing Cloud Access Connector..."
+    RETRIES=3
     export CAM_BASE_URI=${cam_url}
 
     log "--> Running command: $INSTALL_DIR/cloud-access-connector install"
@@ -192,38 +193,79 @@ install_cac() {
     log "--domain ${domain_name} --domain-group ${domain_group}"
     log "--reg-code <pcoip_registration_code> --sync-interval 5"
 
-    if [ -z "${ssl_key}" ]; then
-        log "--insecure"
+    # Set pipefail option to return status of the connector install command
+    set -o pipefail
 
-        $INSTALL_DIR/cloud-access-connector install \
-            -t $CAC_TOKEN \
-            --accept-policies \
-            --insecure \
-            --sa-user ${ad_service_account_username} \
-            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-            --domain ${domain_name} \
-            --domain-group "${domain_group}" \
-            --reg-code $PCOIP_REGISTRATION_CODE \
-            --sync-interval 5 \
-            2>&1 | tee -a $CAC_INSTALL_LOG
+    if [ -z "${ssl_key}" ]; then
+        while true
+        do
+            log "--insecure"
+
+            $INSTALL_DIR/cloud-access-connector install \
+                -t $CAC_TOKEN \
+                --accept-policies \
+                --insecure \
+                --sa-user ${ad_service_account_username} \
+                --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+                --domain ${domain_name} \
+                --domain-group "${domain_group}" \
+                --reg-code $PCOIP_REGISTRATION_CODE \
+                --sync-interval 5 \
+                2>&1 | tee -a $CAC_INSTALL_LOG
+            
+            RC=$?
+            if [ $RC -eq 0 ]
+            then
+                log "--> Successfully installed Cloud Access Connector."
+                break
+            fi
+
+            if [ $RETRIES -eq 0 ]
+            then
+                exit 1
+            fi
+
+            log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+            RETRIES=$((RETRIES-1))
+            sleep 60
+        done
     else
         gsutil cp gs://${bucket_name}/${ssl_key} $INSTALL_DIR
         gsutil cp gs://${bucket_name}/${ssl_cert} $INSTALL_DIR
 
-        log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
+        while true
+        do
+            log "--ssl-key <ssl_key> --ssl-cert <ssl_cert>"
 
-        $INSTALL_DIR/cloud-access-connector install \
-            -t $CAC_TOKEN \
-            --accept-policies \
-            --ssl-key $INSTALL_DIR/${ssl_key} \
-            --ssl-cert $INSTALL_DIR/${ssl_cert} \
-            --sa-user ${ad_service_account_username} \
-            --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
-            --domain ${domain_name} \
-            --domain-group "${domain_group}" \
-            --reg-code $PCOIP_REGISTRATION_CODE \
-            --sync-interval 5 \
-            2>&1 | tee -a $CAC_INSTALL_LOG
+            $INSTALL_DIR/cloud-access-connector install \
+                -t $CAC_TOKEN \
+                --accept-policies \
+                --ssl-key $INSTALL_DIR/${ssl_key} \
+                --ssl-cert $INSTALL_DIR/${ssl_cert} \
+                --sa-user ${ad_service_account_username} \
+                --sa-password "$AD_SERVICE_ACCOUNT_PASSWORD" \
+                --domain ${domain_name} \
+                --domain-group "${domain_group}" \
+                --reg-code $PCOIP_REGISTRATION_CODE \
+                --sync-interval 5 \
+                2>&1 | tee -a $CAC_INSTALL_LOG
+
+            RC=$?
+            if [ $RC -eq 0 ]
+            then
+                log "--> Successfully installed Cloud Access Connector."
+                break
+            fi
+
+            if [ $RETRIES -eq 0 ]
+            then
+                exit 1
+            fi
+
+            log "--> ERROR: Failed to install Cloud Access Connector. $RETRIES retries remaining..."
+            RETRIES=$((RETRIES-1))
+            sleep 60
+        done
     fi
 }
 


### PR DESCRIPTION
When installing the connector, it would sometimes return a DNS error:
"A DNS error occurred. Please verify the DNS configuration on your
connector."

During testing, manual subsequent CAC installations would succeed
without any further issues. As such, retry logic up to three times
has been implemented for the CAC installation.

Signed-off-by: Edwin-Pau <epau@teradici.com>