### PR TITLE
GCP: Use CAM Deployment Service Account

### DIFF
--- a/deployments/gcp/dc-only/terraform.tfvars.sample
+++ b/deployments/gcp/dc-only/terraform.tfvars.sample
@@ -1,8 +1,8 @@
 # Commented out lines represents defaults that can be changed
 # On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
-# Example: gcp_credentials_file = "C:/path/to/cred.json"
+# Example: gcp_credentials_file = "C:/path/to/gcp_cred.json"
 
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west2"

--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -60,8 +60,8 @@ module "cac-igm" {
   gcp_service_account     = var.gcp_service_account
   kms_cryptokey_id        = var.kms_cryptokey_id
   cam_url                 = var.cam_url
+  cam_deployment_sa_file  = var.cam_deployment_sa_file
   pcoip_registration_code = var.pcoip_registration_code
-  cac_token               = var.cac_token
 
   domain_name                 = var.domain_name
   domain_controller_ip        = module.dc.internal-ip

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -1,6 +1,6 @@
 # Commented out lines represents defaults that can be changed
 # On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
-# Example: gcp_credentials_file = "C:/path/to/cred.json"
+# Example: gcp_credentials_file = "C:/path/to/gcp_cred.json"
 
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
@@ -114,4 +114,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
+cam_deployment_sa_file      = "/path/to/cam_deployment_sa_cred.json"

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -2,7 +2,7 @@
 # On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
 # Example: gcp_credentials_file = "C:/path/to/gcp_cred.json"
 
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west2"
@@ -114,4 +114,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cam_deployment_sa_file      = "/path/to/cam_deployment_sa_cred.json"
+cam_deployment_sa_file      = "/path/to/cloud-access-manager-service-account.json"

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -185,7 +185,7 @@ variable "cam_url" {
 }
 
 variable "cam_deployment_sa_file" {
-  description = "Location of CAM deployment-level service account JSON file"
+  description = "Location of CAM Deployment Service Account account JSON file"
   type        = string
 }
 

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -179,19 +179,19 @@ variable "ws_subnet_cidr" {
   default     = "10.0.2.0/24"
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "cam_url" {
+  description = "cam server url."
+  default     = "https://cam.teradici.com"
+}
+
+variable "cam_deployment_sa_file" {
+  description = "Location of CAM deployment-level service account JSON file"
   type        = string
 }
 
 variable "pcoip_registration_code" {
   description = "PCoIP Registration code"
   type        = string
-}
-
-variable "cam_url" {
-  description = "cam server url."
-  default     = "https://cam.teradici.com"
 }
 
 variable "enable_workstation_public_ip" {

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -60,9 +60,9 @@ module "cac" {
   gcp_service_account     = var.gcp_service_account
   kms_cryptokey_id        = var.kms_cryptokey_id
   cam_url                 = var.cam_url
+  cam_deployment_sa_file  = var.cam_deployment_sa_file
   pcoip_registration_code = var.pcoip_registration_code
-  cac_token               = var.cac_token
-
+  
   domain_name                 = var.domain_name
   domain_controller_ip        = module.dc.internal-ip
   ad_service_account_username = var.ad_service_account_username

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -1,6 +1,6 @@
 # Commented out lines represents defaults that can be changed
 # On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
-# Example: gcp_credentials_file = "C:/path/to/cred.json"
+# Example: gcp_credentials_file = "C:/path/to/gcp_cred.json"
 
 gcp_credentials_file = "/path/to/cred.json"
 gcp_project_id       = "your-project-1234"
@@ -101,4 +101,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cac_token                   = "token from Cloud Access Manager for the connector"
+cam_deployment_sa_file      = "/path/to/cam_deployment_sa_cred.json"

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -2,7 +2,7 @@
 # On Windows systems, the default backslash \ path separator must be changed to forward slash for any path variables.
 # Example: gcp_credentials_file = "C:/path/to/gcp_cred.json"
 
-gcp_credentials_file = "/path/to/cred.json"
+gcp_credentials_file = "/path/to/gcp_cred.json"
 gcp_project_id       = "your-project-1234"
 gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.com"
 # gcp_region           = "us-west2"
@@ -101,4 +101,4 @@ dc_admin_password           = "SecuRe_pwd1"
 safe_mode_admin_password    = "SecuRe_pwd2"
 ad_service_account_password = "SecuRe_pwd3"
 pcoip_registration_code     = "ABCDEFGHIJKL@0123-4567-89AB-CDEF"
-cam_deployment_sa_file      = "/path/to/cam_deployment_sa_cred.json"
+cam_deployment_sa_file      = "/path/to/cloud-access-manager-service-account.json"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -165,7 +165,7 @@ variable "cam_url" {
 }
 
 variable "cam_deployment_sa_file" {
-  description = "Location of CAM deployment-level service account JSON file"
+  description = "Location of CAM Deployment Service Account JSON file"
   type        = string
 }
 

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -159,19 +159,19 @@ variable "ws_subnet_cidr" {
   default     = "10.0.2.0/24"
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "cam_url" {
+  description = "cam server url."
+  default     = "https://cam.teradici.com"
+}
+
+variable "cam_deployment_sa_file" {
+  description = "Location of CAM deployment-level service account JSON file"
   type        = string
 }
 
 variable "pcoip_registration_code" {
   description = "PCoIP Registration code"
   type        = string
-}
-
-variable "cam_url" {
-  description = "cam server url."
-  default     = "https://cam.teradici.com"
 }
 
 variable "enable_workstation_public_ip" {

--- a/docs/README-gcp.md
+++ b/docs/README-gcp.md
@@ -17,7 +17,7 @@ Click on the button below to clone this repository in your GCP Cloud Shell and l
 ### Requirements
 - the user must have owner permissions to a GCP project
 - a PCoIP Registration Code is needed. Contact Teradici sales or purchase subscription here: https://www.teradici.com/compare-plans
-- a Cloud Access Manager deployment-level service account is needed. Please see the Cloud Access Manager Setup section below.
+- a Cloud Access Manager Deployment Service Account is needed. Please see the Cloud Access Manager Setup section below.
 - an SSH private / public key pair is required for Terraform to log into Linux hosts.
 - if SSL is involved, the SSL key and certificate files are needed in PEM format.
 - Terraform v0.12.x must be installed. Please download Terraform from https://www.terraform.io/downloads.html
@@ -38,11 +38,11 @@ With a new GCP project:
 ### Cloud Access Manager Setup
 Login to Cloud Access Manager Admin Console at https://cam.teradici.com using a Google G Suite, Google Cloud Identity, or Microsoft business account.
 1. create a new deployment and submit the credentials for the GCP service account created above.
-2. on the "Edit the Deployment" page, under "Deployment Service Accounts", click on the + icon to create a CAM deployment-level service account.
-3. click on "Download JSON file" to download the CAM deployment-level service account credentials file which will be used in terraform.tfvars.
+2. on the "Edit the Deployment" page, under "Deployment Service Accounts", click on the + icon to create a CAM Deployment Service Account.
+3. click on "Download JSON file" to download the CAM Deployment Service Account credentials file which will be used in terraform.tfvars.
 
 ### (Optional) Encrypting Secrets
-Secrets required as input to the Terraform scripts include Active Directory passwords, PCoIP registration key and the CAM deployment-level service account credentials file. These secrets are stored in the local files terraform.tfvars and terraform.tfstate, and will also be uploaded as part of provisioning scripts to a Google Cloud Storage bucket.
+Secrets required as input to the Terraform scripts include Active Directory passwords, PCoIP registration key and the CAM Deployment Service Account credentials file. These secrets are stored in the local files terraform.tfvars and terraform.tfstate, and will also be uploaded as part of provisioning scripts to a Google Cloud Storage bucket.
 
 The Terraform scripts are designed to support both plaintext and KMS-encrypted secrets. Plaintext secrets requires no extra steps, but will be stored in plaintext in the above mentioned locations. It is recommended to encrypt the secrets in the terraform.tfvars file before deploying. Secrets can be encrypted manually first before being entered into terraform.tfvars, or they can be encrypted using a python script located under tools.
 
@@ -51,7 +51,7 @@ To encrypt secrets using the KMS crypto key created above, follow the instructio
 
 ```echo -n <secret> | gcloud kms encrypt --location <location> --keyring <keyring_name> --key <key_name> --plaintext-file - --ciphertext-file - | base64```
 
-If using encryption, the CAM deployment-level service account credentials file must also be encrypted. To encrypt, open the file and replace the contents of the file with the ciphertext.
+If using encryption, the CAM Deployment Service Account credentials file must also be encrypted. To encrypt, open the file and replace the contents of the file with the ciphertext.
 
 #### Encryption Using Python Script
 Alternatively, the kms_secrets_encryption.py Python 3 script under the tools directory can be used to automate the KMS encryption process. 
@@ -118,7 +118,7 @@ Firewall rules are created to allow wide-open access within the VPC, and selecte
 
 A Domain Controller is created with Active Directory, DNS and LDAP-S configured. 2 Domain Admins are set up in the new domain: ```Administrator``` and ```cam_admin``` (default). Domain Users are also created if a ```domain_users_list``` CSV file is specified. The Domain Controller is given a static IP (configurable).
 
-A Cloud Access Connector is created and registers itself with the CAM service with the given CAM deployment-level service account credentials and PCoIP Registration code.
+A Cloud Access Connector is created and registers itself with the CAM service with the given CAM Deployment Service Account credentials and PCoIP Registration code.
 
 Domain-joined workstations are optionally created, specified by the following parameters:
 - ```win_gfx_instance_count```: Windows Graphics workstation,

--- a/docs/README-gcp.md
+++ b/docs/README-gcp.md
@@ -17,6 +17,7 @@ Click on the button below to clone this repository in your GCP Cloud Shell and l
 ### Requirements
 - the user must have owner permissions to a GCP project
 - a PCoIP Registration Code is needed. Contact Teradici sales or purchase subscription here: https://www.teradici.com/compare-plans
+- a Cloud Access Manager deployment-level service account is needed. Please see the Cloud Access Manager Setup section below.
 - an SSH private / public key pair is required for Terraform to log into Linux hosts.
 - if SSL is involved, the SSL key and certificate files are needed in PEM format.
 - Terraform v0.12.x must be installed. Please download Terraform from https://www.terraform.io/downloads.html
@@ -37,10 +38,11 @@ With a new GCP project:
 ### Cloud Access Manager Setup
 Login to Cloud Access Manager Admin Console at https://cam.teradici.com using a Google G Suite, Google Cloud Identity, or Microsoft business account.
 1. create a new deployment and submit the credentials for the GCP service account created above.
-1. create a Connector in the new deployment. A connector token will be generated to be used in terraform.tfvars.
+2. on the "Edit the Deployment" page, under "Deployment Service Accounts", click on the + icon to create a CAM deployment-level service account.
+3. click on "Download JSON file" to download the CAM deployment-level service account credentials file which will be used in terraform.tfvars.
 
 ### (Optional) Encrypting Secrets
-Secrets required as input to the Terraform scripts include Active Directory passwords, PCoIP registration key and the connector token. These secrets are stored in the local files terraform.tfvars and terraform.tfstate, and will also be uploaded as part of provisioning scripts to a Google Cloud Storage bucket.
+Secrets required as input to the Terraform scripts include Active Directory passwords, PCoIP registration key and the CAM deployment-level service account credentials file. These secrets are stored in the local files terraform.tfvars and terraform.tfstate, and will also be uploaded as part of provisioning scripts to a Google Cloud Storage bucket.
 
 The Terraform scripts are designed to support both plaintext and KMS-encrypted secrets. Plaintext secrets requires no extra steps, but will be stored in plaintext in the above mentioned locations. It is recommended to encrypt the secrets in the terraform.tfvars file before deploying. Secrets can be encrypted manually first before being entered into terraform.tfvars, or they can be encrypted using a python script located under tools.
 
@@ -48,6 +50,8 @@ The Terraform scripts are designed to support both plaintext and KMS-encrypted s
 To encrypt secrets using the KMS crypto key created above, follow the instructions here: https://cloud.google.com/kms/docs/encrypt-decrypt. Base64 encode the ciphertext before copying and pasting it into terraform.tfvars. For example, execute the following command in GCP Cloud Shell:
 
 ```echo -n <secret> | gcloud kms encrypt --location <location> --keyring <keyring_name> --key <key_name> --plaintext-file - --ciphertext-file - | base64```
+
+If using encryption, the CAM deployment-level service account credentials file must also be encrypted. To encrypt, open the file and replace the contents of the file with the ciphertext.
 
 #### Encryption Using Python Script
 Alternatively, the kms_secrets_encryption.py Python 3 script under the tools directory can be used to automate the KMS encryption process. 
@@ -74,7 +78,7 @@ If secrets are KMS-encrypted, fill in the ```kms_cryptokey_id``` variable with t
 - ```safe_mode_admin_password```
 - ```ad_service_account_password```
 - ```pcoip_registration_code```
-- ```cac_token```
+- ```cam_deployment_sa_file```
 
 Be sure to remove any spaces in the ciphertext.
 
@@ -114,7 +118,7 @@ Firewall rules are created to allow wide-open access within the VPC, and selecte
 
 A Domain Controller is created with Active Directory, DNS and LDAP-S configured. 2 Domain Admins are set up in the new domain: ```Administrator``` and ```cam_admin``` (default). Domain Users are also created if a ```domain_users_list``` CSV file is specified. The Domain Controller is given a static IP (configurable).
 
-A Cloud Access Connector is created and registers itself with the CAM service with the given Token and PCoIP Registration code.
+A Cloud Access Connector is created and registers itself with the CAM service with the given CAM deployment-level service account credentials and PCoIP Registration code.
 
 Domain-joined workstations are optionally created, specified by the following parameters:
 - ```win_gfx_instance_count```: Windows Graphics workstation,

--- a/modules/gcp/cac-igm/cac-cam.py
+++ b/modules/gcp/cac-igm/cac-cam.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2020 Teradici Corporation
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+import os
+import requests
+import sys
+
+API_URL = None
+
+
+def create_connector_name():
+    """A function to create a custom connector name
+    
+    Uses metadata server to access instance data, which is used to create the connector name.
+    
+    Returns:
+        string: a string for the connector name
+    """
+
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/"
+    headers      = {"Metadata-Flavor": "Google"}
+
+    response_zone = requests.get(metadata_url + "zone", headers = headers)
+    response_name = requests.get(metadata_url + "name", headers = headers)
+
+    zone = response_zone.text.rpartition('/')[2]
+    name = response_name.text
+
+    connector_name = "{}-{}".format(zone, name)
+
+    return connector_name
+
+
+def get_auth_token(filepath):
+    """A function to retrieve a CAM authentication token
+    
+    Uses a CAM deployment-level service account JSON file to request a CAM authentication token.
+    
+    Args:
+        filepath (str): the location of CAM deployment-level service account JSON file
+    Returns:
+        string: a string for the CAM authentication token
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    request_body = dict(username = cam_credentials.get('username'), 
+                        password = cam_credentials.get('apiKey'),
+                        tenantId = cam_credentials.get('tenantId'))
+
+    response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body = response.json()
+    auth_token    = response_body.get('data').get('token')
+
+    return auth_token
+
+
+def get_deployment_id(filepath):
+    """A function to parse the deployment ID
+    
+    Parses the deployment ID from the CAM deployment-level service account JSON file.
+    
+    Args:
+        filepath (str): the location of CAM deployment-level service account JSON file
+    Returns:
+        string: a string for the deployment ID
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    return cam_credentials.get('deploymentId')
+
+
+def get_cac_token(auth_token, deployment_id, connector_name):
+    """A function to create a connector token
+    
+    Creates a connector token using the authentication token and deployment ID.
+    
+    Args:
+        auth_token (str)    : auth_token created using CAM deployment-level service account
+        deployment_id (str) : a string for the deployment ID
+    	connector_name (str): a string for the connector name
+    Returns:
+        string: a string for the connector token
+    """
+
+    session = requests.Session()
+    session.headers.update({"Authorization": auth_token})
+
+    body = dict(deploymentId  = deployment_id, 
+                connectorName = connector_name)
+
+    response = session.post("{}/auth/tokens/connector".format(API_URL), json=body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body   = response.json()
+    connector_token = response_body.get('data').get('token')
+
+    return connector_token
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This script uses CAM deployment-level service account JSON file to create a new connector token.")
+
+    parser.add_argument("cam", help="specify the path to CAM deployment-level service account JSON file")
+    parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
+    args = parser.parse_args()
+
+    # Allow user to override default CAM URL
+    global API_URL
+    API_URL = args.url
+
+    auth_token     = get_auth_token(args.cam)
+    deployment_id  = get_deployment_id(args.cam)
+    connector_name = create_connector_name()
+    cac_token      = get_cac_token(auth_token, deployment_id, connector_name)
+
+    return cac_token
+
+
+if __name__ == '__main__':
+    try:
+        # Print the cac_token string as the output of this script
+        print(main())
+    except:
+        # Prevent bash from interpreting any error messages
+        sys.exit(1)

--- a/modules/gcp/cac-igm/cac-cam.py
+++ b/modules/gcp/cac-igm/cac-cam.py
@@ -51,13 +51,13 @@ def get_auth_token(filepath):
     try:
         with open(filepath) as f:
             cam_credentials = json.load(f)
+
     except Exception as err:
         print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
-        raise ex
+        raise err
 
     request_body = dict(username = cam_credentials.get('username'), 
-                        password = cam_credentials.get('apiKey'),
-                        tenantId = cam_credentials.get('tenantId'))
+                        password = cam_credentials.get('apiKey'))
 
     response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
 
@@ -84,9 +84,10 @@ def get_deployment_id(filepath):
     try:
         with open(filepath) as f:
             cam_credentials = json.load(f)
+
     except Exception as err:
         print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
-        raise ex
+        raise err
 
     return cam_credentials.get('deploymentId')
 
@@ -144,6 +145,7 @@ if __name__ == '__main__':
     try:
         # Print the cac_token string as the output of this script
         print(main())
+
     except:
         # Prevent bash from interpreting any error messages
         sys.exit(1)

--- a/modules/gcp/cac-igm/cac-cam.py
+++ b/modules/gcp/cac-igm/cac-cam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Teradici Corporation
 #

--- a/modules/gcp/cac-igm/cac-cam.py
+++ b/modules/gcp/cac-igm/cac-cam.py
@@ -40,10 +40,10 @@ def create_connector_name():
 def get_auth_token(filepath):
     """A function to retrieve a CAM authentication token
     
-    Uses a CAM deployment-level service account JSON file to request a CAM authentication token.
+    Uses a CAM Deployment Service Account JSON file to request a CAM authentication token.
     
     Args:
-        filepath (str): the location of CAM deployment-level service account JSON file
+        filepath (str): the location of CAM Deployment Service Account JSON file
     Returns:
         string: a string for the CAM authentication token
     """
@@ -53,7 +53,7 @@ def get_auth_token(filepath):
             cam_credentials = json.load(f)
 
     except Exception as err:
-        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        print("Exception occurred opening CAM Deployment Service Account JSON file. Exiting CAM script...\n{}".format(err))
         raise err
 
     request_body = dict(username = cam_credentials.get('username'), 
@@ -73,10 +73,10 @@ def get_auth_token(filepath):
 def get_deployment_id(filepath):
     """A function to parse the deployment ID
     
-    Parses the deployment ID from the CAM deployment-level service account JSON file.
+    Parses the deployment ID from the CAM Deployment Service Account JSON file.
     
     Args:
-        filepath (str): the location of CAM deployment-level service account JSON file
+        filepath (str): the location of CAM Deployment Service Account JSON file
     Returns:
         string: a string for the deployment ID
     """
@@ -86,7 +86,7 @@ def get_deployment_id(filepath):
             cam_credentials = json.load(f)
 
     except Exception as err:
-        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        print("Exception occurred opening CAM Deployment Service Account JSON file. Exiting CAM script...\n{}".format(err))
         raise err
 
     return cam_credentials.get('deploymentId')
@@ -98,7 +98,7 @@ def get_cac_token(auth_token, deployment_id, connector_name):
     Creates a connector token using the authentication token and deployment ID.
     
     Args:
-        auth_token (str)    : auth_token created using CAM deployment-level service account
+        auth_token (str)    : auth_token created using CAM Deployment Service Account
         deployment_id (str) : a string for the deployment ID
     	connector_name (str): a string for the connector name
     Returns:
@@ -123,9 +123,9 @@ def get_cac_token(auth_token, deployment_id, connector_name):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="This script uses CAM deployment-level service account JSON file to create a new connector token.")
+    parser = argparse.ArgumentParser(description="This script uses CAM Deployment Service Account JSON file to create a new connector token.")
 
-    parser.add_argument("cam", help="specify the path to CAM deployment-level service account JSON file")
+    parser.add_argument("cam", help="specify the path to CAM Deployment Service Account JSON file")
     parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
     args = parser.parse_args()
 

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -24,19 +24,25 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$LOG_FILE"
 }
 
+install_python() {
+    log "--> Installing Python and Python3..."
+    apt-get -qq update
+    apt install -y python
+    apt install -y python3
+}
+
 get_credentials() {
+    log "--> Downloading CAM deployment-level service account JSON file from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_deployment_sa_file} $INSTALL_DIR
+
     if [[ -z "${kms_cryptokey_id}" ]]; then
         log "--> Script is not using encryption for secrets."
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
-        CAC_TOKEN=${cac_token}
 
     else
         log "--> Script is using encryption key: ${kms_cryptokey_id}"
-
-        apt-get -qq update
-        apt install -y python
 
         # Gets access token attribute of response json object
         token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
@@ -52,10 +58,29 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        log "--> Decrypting CAC token..."
-        data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
+        log "--> Decrypting CAM deployment-level service account JSON file..."
+        cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
+        data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        CAC_TOKEN=$(echo "$b64_data" | base64 --decode)
+        CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
+        echo $CAM_CREDENTIALS | tee ${cam_deployment_sa_file}
+    fi
+}
+
+get_cac_token() {
+    log "--> Retrieving connector token before CAC install..."
+
+    log "--> Downloading CAM python script from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
+    chmod +x ${cam_script}
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`./${cam_script} ${cam_deployment_sa_file}`
+
+    # Check and exit startup script if retrieving connector token failed
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting startup script..."
+        exit 1
     fi
 }
 
@@ -236,7 +261,11 @@ fi
 
 log "$(date)"
 
+install_python
+
 get_credentials
+
+get_cac_token
 
 check_required_vars
 

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -32,7 +32,7 @@ install_python() {
 }
 
 get_credentials() {
-    log "--> Downloading CAM deployment-level service account JSON file from the bucket..."
+    log "--> Downloading CAM Deployment Service Account JSON file from the bucket..."
     gsutil cp gs://${bucket_name}/${cam_deployment_sa_file} $INSTALL_DIR
 
     if [[ -z "${kms_cryptokey_id}" ]]; then
@@ -58,7 +58,7 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        log "--> Decrypting CAM deployment-level service account JSON file..."
+        log "--> Decrypting CAM Deployment Service Account JSON file..."
         cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
         data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")

--- a/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac-igm/cac-provisioning.sh.tmpl
@@ -25,10 +25,14 @@ log() {
 }
 
 install_python() {
-    log "--> Installing Python and Python3..."
+    log "--> Installing Python3..."
     apt-get -qq update
-    apt install -y python
     apt install -y python3
+
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to install Python3. Exiting provisioning script..."
+        exit 1
+    fi
 }
 
 get_credentials() {
@@ -45,25 +49,25 @@ get_credentials() {
         log "--> Script is using encryption key: ${kms_cryptokey_id}"
 
         # Gets access token attribute of response json object
-        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
+        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
 
         # Gets data using access token and decodes it
         log "--> Decrypting PCoIP registration code..."
         data=$(echo "{ \"ciphertext\": \"${pcoip_registration_code}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
         log "--> Decrypting AD service account password..."
         data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
         log "--> Decrypting CAM Deployment Service Account JSON file..."
-        cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
+        cam_cred_encrypted=$(cat $INSTALL_DIR/${cam_deployment_sa_file})
         data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
-        echo $CAM_CREDENTIALS | tee ${cam_deployment_sa_file}
+        echo $CAM_CREDENTIALS | tee $INSTALL_DIR/${cam_deployment_sa_file}
     fi
 }
 
@@ -72,14 +76,14 @@ get_cac_token() {
 
     log "--> Downloading CAM python script from the bucket..."
     gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
-    chmod +x ${cam_script}
+    chmod +x $INSTALL_DIR/${cam_script}
 
     # Set CAC_TOKEN variable using the script's output
-    CAC_TOKEN=`./${cam_script} ${cam_deployment_sa_file}`
+    CAC_TOKEN=`$INSTALL_DIR/${cam_script} $INSTALL_DIR/${cam_deployment_sa_file}`
 
     # Check and exit startup script if retrieving connector token failed
     if [ $? -ne 0 ]; then
-        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting startup script..."
+        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting provisioning script..."
         exit 1
     fi
 }

--- a/modules/gcp/cac-igm/main.tf
+++ b/modules/gcp/cac-igm/main.tf
@@ -86,6 +86,13 @@ resource "google_storage_bucket_object" "cac-provisioning-script" {
 resource "google_compute_instance_template" "cac-template" {
   count = local.num_regions
 
+  depends_on = [
+    google_storage_bucket_object.cam-deployment-sa-file,
+    google_storage_bucket_object.cac-cam-script,
+    # Provisioning script dependency should be inferred by Terraform
+    # google_storage_bucket_object.cac-provisioning-script,
+  ]
+
   name_prefix = "${local.prefix}template-cac-${var.gcp_zone_list[count.index]}"
 
   machine_type = var.machine_type

--- a/modules/gcp/cac-igm/main.tf
+++ b/modules/gcp/cac-igm/main.tf
@@ -44,7 +44,7 @@ resource "google_storage_bucket_object" "cac-cam-script" {
 
   bucket = var.bucket_name
   name   = local.cam_script
-  source = "${path.module}/cac-cam.py"
+  source = "${path.module}/${local.cam_script}"
 }
 
 # This is needed so new VMs will be based on the same image in case the public

--- a/modules/gcp/cac-igm/vars.tf
+++ b/modules/gcp/cac-igm/vars.tf
@@ -21,7 +21,7 @@ variable "cam_url" {
 }
 
 variable "cam_deployment_sa_file" {
-  description = "Location of CAM deployment-level service account JSON file"
+  description = "Location of CAM Deployment Service Account JSON file"
   type        = string
 }
 

--- a/modules/gcp/cac-igm/vars.tf
+++ b/modules/gcp/cac-igm/vars.tf
@@ -20,13 +20,13 @@ variable "cam_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_registration_code" {
-  description = "PCoIP Registration code"
+variable "cam_deployment_sa_file" {
+  description = "Location of CAM deployment-level service account JSON file"
   type        = string
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "pcoip_registration_code" {
+  description = "PCoIP Registration code"
   type        = string
 }
 

--- a/modules/gcp/cac/cac-cam.py
+++ b/modules/gcp/cac/cac-cam.py
@@ -1,0 +1,149 @@
+#!/usr/bin/python3
+
+# Copyright (c) 2020 Teradici Corporation
+#
+# This source code is licensed under the MIT license found in the
+# LICENSE file in the root directory of this source tree.
+
+import argparse
+import json
+import os
+import requests
+import sys
+
+API_URL = None
+
+
+def create_connector_name():
+    """A function to create a custom connector name
+    
+    Uses metadata server to access instance data, which is used to create the connector name.
+    
+    Returns:
+        string: a string for the connector name
+    """
+
+    metadata_url = "http://metadata.google.internal/computeMetadata/v1/instance/"
+    headers      = {"Metadata-Flavor": "Google"}
+
+    response_zone = requests.get(metadata_url + "zone", headers = headers)
+    response_name = requests.get(metadata_url + "name", headers = headers)
+
+    zone = response_zone.text.rpartition('/')[2]
+    name = response_name.text
+
+    connector_name = "{}-{}".format(zone, name)
+
+    return connector_name
+
+
+def get_auth_token(filepath):
+    """A function to retrieve a CAM authentication token
+    
+    Uses a CAM deployment-level service account JSON file to request a CAM authentication token.
+    
+    Args:
+        filepath (str): the location of CAM deployment-level service account JSON file
+    Returns:
+        string: a string for the CAM authentication token
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    request_body = dict(username = cam_credentials.get('username'), 
+                        password = cam_credentials.get('apiKey'),
+                        tenantId = cam_credentials.get('tenantId'))
+
+    response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body = response.json()
+    auth_token    = response_body.get('data').get('token')
+
+    return auth_token
+
+
+def get_deployment_id(filepath):
+    """A function to parse the deployment ID
+    
+    Parses the deployment ID from the CAM deployment-level service account JSON file.
+    
+    Args:
+        filepath (str): the location of CAM deployment-level service account JSON file
+    Returns:
+        string: a string for the deployment ID
+    """
+
+    try:
+        with open(filepath) as f:
+            cam_credentials = json.load(f)
+    except Exception as err:
+        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        raise ex
+
+    return cam_credentials.get('deploymentId')
+
+
+def get_cac_token(auth_token, deployment_id, connector_name):
+    """A function to create a connector token
+    
+    Creates a connector token using the authentication token and deployment ID.
+    
+    Args:
+        auth_token (str)    : auth_token created using CAM deployment-level service account
+        deployment_id (str) : a string for the deployment ID
+    	connector_name (str): a string for the connector name
+    Returns:
+        string: a string for the connector token
+    """
+
+    session = requests.Session()
+    session.headers.update({"Authorization": auth_token})
+
+    body = dict(deploymentId  = deployment_id, 
+                connectorName = connector_name)
+
+    response = session.post("{}/auth/tokens/connector".format(API_URL), json=body)
+
+    if not response.status_code == 200:
+        raise Exception(response.text)
+
+    response_body   = response.json()
+    connector_token = response_body.get('data').get('token')
+
+    return connector_token
+
+
+def main():
+    parser = argparse.ArgumentParser(description="This script uses CAM deployment-level service account JSON file to create a new connector token.")
+
+    parser.add_argument("cam", help="specify the path to CAM deployment-level service account JSON file")
+    parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
+    args = parser.parse_args()
+
+    # Allow user to override default CAM URL
+    global API_URL
+    API_URL = args.url
+
+    auth_token     = get_auth_token(args.cam)
+    deployment_id  = get_deployment_id(args.cam)
+    connector_name = create_connector_name()
+    cac_token      = get_cac_token(auth_token, deployment_id, connector_name)
+
+    return cac_token
+
+
+if __name__ == '__main__':
+    try:
+        # Print the cac_token string as the output of this script
+        print(main())
+    except:
+        # Prevent bash from interpreting any error messages
+        sys.exit(1)

--- a/modules/gcp/cac/cac-cam.py
+++ b/modules/gcp/cac/cac-cam.py
@@ -51,13 +51,13 @@ def get_auth_token(filepath):
     try:
         with open(filepath) as f:
             cam_credentials = json.load(f)
+
     except Exception as err:
         print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
-        raise ex
+        raise err
 
     request_body = dict(username = cam_credentials.get('username'), 
-                        password = cam_credentials.get('apiKey'),
-                        tenantId = cam_credentials.get('tenantId'))
+                        password = cam_credentials.get('apiKey'))
 
     response = requests.post("{}/auth/signin".format(API_URL), json = request_body)
 
@@ -84,9 +84,10 @@ def get_deployment_id(filepath):
     try:
         with open(filepath) as f:
             cam_credentials = json.load(f)
+
     except Exception as err:
         print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
-        raise ex
+        raise err
 
     return cam_credentials.get('deploymentId')
 
@@ -144,6 +145,7 @@ if __name__ == '__main__':
     try:
         # Print the cac_token string as the output of this script
         print(main())
+
     except:
         # Prevent bash from interpreting any error messages
         sys.exit(1)

--- a/modules/gcp/cac/cac-cam.py
+++ b/modules/gcp/cac/cac-cam.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Teradici Corporation
 #

--- a/modules/gcp/cac/cac-cam.py
+++ b/modules/gcp/cac/cac-cam.py
@@ -40,10 +40,10 @@ def create_connector_name():
 def get_auth_token(filepath):
     """A function to retrieve a CAM authentication token
     
-    Uses a CAM deployment-level service account JSON file to request a CAM authentication token.
+    Uses a CAM Deployment Service Account JSON file to request a CAM authentication token.
     
     Args:
-        filepath (str): the location of CAM deployment-level service account JSON file
+        filepath (str): the location of CAM Deployment Service Account JSON file
     Returns:
         string: a string for the CAM authentication token
     """
@@ -53,7 +53,7 @@ def get_auth_token(filepath):
             cam_credentials = json.load(f)
 
     except Exception as err:
-        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        print("Exception occurred opening CAM Deployment Service Account JSON file. Exiting CAM script...\n{}".format(err))
         raise err
 
     request_body = dict(username = cam_credentials.get('username'), 
@@ -73,10 +73,10 @@ def get_auth_token(filepath):
 def get_deployment_id(filepath):
     """A function to parse the deployment ID
     
-    Parses the deployment ID from the CAM deployment-level service account JSON file.
+    Parses the deployment ID from the CAM Deployment Service Account JSON file.
     
     Args:
-        filepath (str): the location of CAM deployment-level service account JSON file
+        filepath (str): the location of CAM Deployment Service Account JSON file
     Returns:
         string: a string for the deployment ID
     """
@@ -86,7 +86,7 @@ def get_deployment_id(filepath):
             cam_credentials = json.load(f)
 
     except Exception as err:
-        print("Exception occurred opening CAM deployment-level service account JSON file. Exiting CAM script...\n{}".format(err))
+        print("Exception occurred opening CAM Deployment Service Account JSON file. Exiting CAM script...\n{}".format(err))
         raise err
 
     return cam_credentials.get('deploymentId')
@@ -98,7 +98,7 @@ def get_cac_token(auth_token, deployment_id, connector_name):
     Creates a connector token using the authentication token and deployment ID.
     
     Args:
-        auth_token (str)    : auth_token created using CAM deployment-level service account
+        auth_token (str)    : auth_token created using CAM Deployment Service Account
         deployment_id (str) : a string for the deployment ID
     	connector_name (str): a string for the connector name
     Returns:
@@ -123,9 +123,9 @@ def get_cac_token(auth_token, deployment_id, connector_name):
 
 
 def main():
-    parser = argparse.ArgumentParser(description="This script uses CAM deployment-level service account JSON file to create a new connector token.")
+    parser = argparse.ArgumentParser(description="This script uses CAM Deployment Service Account JSON file to create a new connector token.")
 
-    parser.add_argument("cam", help="specify the path to CAM deployment-level service account JSON file")
+    parser.add_argument("cam", help="specify the path to CAM Deployment Service Account JSON file")
     parser.add_argument("--url", default="https://cam.teradici.com/api/v1", help="specify the api url")
     args = parser.parse_args()
 

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -24,19 +24,25 @@ log() {
     echo "[$(date)] $${message}" | tee -a "$LOG_FILE"
 }
 
+install_python() {
+    log "--> Installing Python and Python3..."
+    apt-get -qq update
+    apt install -y python
+    apt install -y python3
+}
+
 get_credentials() {
+    log "--> Downloading CAM deployment-level service account JSON file from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_deployment_sa_file} $INSTALL_DIR
+
     if [[ -z "${kms_cryptokey_id}" ]]; then
         log "--> Script is not using encryption for secrets."
 
         PCOIP_REGISTRATION_CODE=${pcoip_registration_code}
         AD_SERVICE_ACCOUNT_PASSWORD=${ad_service_account_password}
-        CAC_TOKEN=${cac_token}
 
     else
         log "--> Script is using encryption key: ${kms_cryptokey_id}"
-
-        apt-get -qq update
-        apt install -y python
 
         # Gets access token attribute of response json object
         token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
@@ -52,10 +58,29 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        log "--> Decrypting CAC token..."
-        data=$(echo "{ \"ciphertext\": \"${cac_token}\" }")
+        log "--> Decrypting CAM deployment-level service account JSON file..."
+        cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
+        data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
-        CAC_TOKEN=$(echo "$b64_data" | base64 --decode)
+        CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
+        echo $CAM_CREDENTIALS | tee ${cam_deployment_sa_file}
+    fi
+}
+
+get_cac_token() {
+    log "--> Retrieving connector token before CAC install..."
+
+    log "--> Downloading CAM python script from the bucket..."
+    gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
+    chmod +x ${cam_script}
+
+    # Set CAC_TOKEN variable using the script's output
+    CAC_TOKEN=`./${cam_script} ${cam_deployment_sa_file}`
+
+    # Check and exit startup script if retrieving connector token failed
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting startup script..."
+        exit 1
     fi
 }
 
@@ -236,7 +261,11 @@ fi
 
 log "$(date)"
 
+install_python
+
 get_credentials
+
+get_cac_token
 
 check_required_vars
 

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -32,7 +32,7 @@ install_python() {
 }
 
 get_credentials() {
-    log "--> Downloading CAM deployment-level service account JSON file from the bucket..."
+    log "--> Downloading CAM Deployment Service Account JSON file from the bucket..."
     gsutil cp gs://${bucket_name}/${cam_deployment_sa_file} $INSTALL_DIR
 
     if [[ -z "${kms_cryptokey_id}" ]]; then
@@ -58,7 +58,7 @@ get_credentials() {
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
-        log "--> Decrypting CAM deployment-level service account JSON file..."
+        log "--> Decrypting CAM Deployment Service Account JSON file..."
         cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
         data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
         b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")

--- a/modules/gcp/cac/cac-provisioning.sh.tmpl
+++ b/modules/gcp/cac/cac-provisioning.sh.tmpl
@@ -25,10 +25,14 @@ log() {
 }
 
 install_python() {
-    log "--> Installing Python and Python3..."
+    log "--> Installing Python3..."
     apt-get -qq update
-    apt install -y python
     apt install -y python3
+
+    if [ $? -ne 0 ]; then
+        log "--> ERROR: Failed to install Python3. Exiting provisioning script..."
+        exit 1
+    fi
 }
 
 get_credentials() {
@@ -45,25 +49,25 @@ get_credentials() {
         log "--> Script is using encryption key: ${kms_cryptokey_id}"
 
         # Gets access token attribute of response json object
-        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python -c "import sys, json; print json.load(sys.stdin)['access_token']")
+        token=$(curl "$METADATA_AUTH_URI" -H "Metadata-Flavor: Google" | python3 -c "import sys, json; print(json.load(sys.stdin)['access_token'])")
 
         # Gets data using access token and decodes it
         log "--> Decrypting PCoIP registration code..."
         data=$(echo "{ \"ciphertext\": \"${pcoip_registration_code}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         PCOIP_REGISTRATION_CODE=$(echo "$b64_data" | base64 --decode)
 
         log "--> Decrypting AD service account password..."
         data=$(echo "{ \"ciphertext\": \"${ad_service_account_password}\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         AD_SERVICE_ACCOUNT_PASSWORD=$(echo "$b64_data" | base64 --decode)
 
         log "--> Decrypting CAM Deployment Service Account JSON file..."
-        cam_cred_encrypted=$(cat ${cam_deployment_sa_file})
+        cam_cred_encrypted=$(cat $INSTALL_DIR/${cam_deployment_sa_file})
         data=$(echo "{ \"ciphertext\": \"$cam_cred_encrypted\" }")
-        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python -c "import sys, json; print json.load(sys.stdin)['plaintext']")
+        b64_data=$(curl -X POST -d "$data" "$DECRYPT_URI" -H "Authorization: Bearer $token" -H "Content-type: application/json" | python3 -c "import sys, json; print(json.load(sys.stdin)['plaintext'])")
         CAM_CREDENTIALS=$(echo "$b64_data" | base64 --decode)
-        echo $CAM_CREDENTIALS | tee ${cam_deployment_sa_file}
+        echo $CAM_CREDENTIALS | tee $INSTALL_DIR/${cam_deployment_sa_file}
     fi
 }
 
@@ -72,14 +76,14 @@ get_cac_token() {
 
     log "--> Downloading CAM python script from the bucket..."
     gsutil cp gs://${bucket_name}/${cam_script} $INSTALL_DIR
-    chmod +x ${cam_script}
+    chmod +x $INSTALL_DIR/${cam_script}
 
     # Set CAC_TOKEN variable using the script's output
-    CAC_TOKEN=`./${cam_script} ${cam_deployment_sa_file}`
+    CAC_TOKEN=`$INSTALL_DIR/${cam_script} $INSTALL_DIR/${cam_deployment_sa_file}`
 
     # Check and exit startup script if retrieving connector token failed
     if [ $? -ne 0 ]; then
-        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting startup script..."
+        log "--> ERROR: Failed to retrieve connector token using CAM script. Exiting provisioning script..."
         exit 1
     fi
 }

--- a/modules/gcp/cac/main.tf
+++ b/modules/gcp/cac/main.tf
@@ -29,7 +29,7 @@ resource "google_storage_bucket_object" "cac-cam-script" {
 
   bucket  = var.bucket_name
   name   = local.cam_script
-  source = "${path.module}/cac-cam.py"
+  source = "${path.module}/${local.cam_script}"
 }
 
 resource "google_storage_bucket_object" "ssl-key" {

--- a/modules/gcp/cac/main.tf
+++ b/modules/gcp/cac/main.tf
@@ -6,10 +6,30 @@
  */
 
 locals {
-  prefix            = var.prefix != "" ? "${var.prefix}-" : ""
-  provisioning_script    = "cac-provisioning.sh"
+  prefix = var.prefix != "" ? "${var.prefix}-" : ""
+
+  provisioning_script  = "cac-provisioning.sh"
+  cam_script           = "cac-cam.py"
+  cam_deployment_sa_file = "cam-cred.json"
+  
   ssl_key_filename  = var.ssl_key == "" ? "" : basename(var.ssl_key)
   ssl_cert_filename = var.ssl_cert == "" ? "" : basename(var.ssl_cert)
+}
+
+resource "google_storage_bucket_object" "cam-credentials-file" {
+  count = tonumber(var.instance_count) == 0 ? 0 : 1
+
+  bucket  = var.bucket_name
+  name    = local.cam_deployment_sa_file
+  source  = var.cam_deployment_sa_file
+}
+
+resource "google_storage_bucket_object" "cac-cam-script" {
+  count = tonumber(var.instance_count) == 0 ? 0 : 1
+
+  bucket  = var.bucket_name
+  name   = local.cam_script
+  source = "${path.module}/cac-cam.py"
 }
 
 resource "google_storage_bucket_object" "ssl-key" {
@@ -44,7 +64,8 @@ resource "google_storage_bucket_object" "cac-provisioning-script" {
       kms_cryptokey_id            = var.kms_cryptokey_id,
       cam_url                     = var.cam_url,
       cac_installer_url           = var.cac_installer_url,
-      cac_token                   = var.cac_token,
+      cam_deployment_sa_file      = local.cam_deployment_sa_file,
+      cam_script                  = local.cam_script,
       pcoip_registration_code     = var.pcoip_registration_code,
 
       domain_controller_ip        = var.domain_controller_ip,

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -21,7 +21,7 @@ variable "cam_url" {
 }
 
 variable "cam_deployment_sa_file" {
-  description = "Location of CAM deployment-level service account JSON file"
+  description = "Location of CAM Deployment Service Account JSON file"
   type        = string
 }
 

--- a/modules/gcp/cac/vars.tf
+++ b/modules/gcp/cac/vars.tf
@@ -20,13 +20,13 @@ variable "cam_url" {
   default     = "https://cam.teradici.com"
 }
 
-variable "pcoip_registration_code" {
-  description = "PCoIP Registration code"
+variable "cam_deployment_sa_file" {
+  description = "Location of CAM deployment-level service account JSON file"
   type        = string
 }
 
-variable "cac_token" {
-  description = "Connector Token from CAM Service"
+variable "pcoip_registration_code" {
+  description = "PCoIP Registration code"
   type        = string
 }
 

--- a/quickstart/cam.py
+++ b/quickstart/cam.py
@@ -48,6 +48,21 @@ class CloudAccessManager:
         )
         resp.raise_for_status()
 
+    def deployment_key_create(self, deployment):
+        deployment_id = {
+            'deploymentId': deployment['deploymentId']
+        }
+
+        # this is the deployment service account endpoint
+        resp = requests.post(
+            self.url + '/api/v1/auth/keys',
+            headers = self.header,
+            json = deployment_id,
+        )
+        resp.raise_for_status()
+
+        return resp.json()['data']
+
     def connector_create(self, name, deployment):
         connector_details = {
             'createdBy':     deployment['createdBy'],

--- a/quickstart/cam.py
+++ b/quickstart/cam.py
@@ -48,16 +48,17 @@ class CloudAccessManager:
         )
         resp.raise_for_status()
 
-    def deployment_key_create(self, deployment):
-        deployment_id = {
-            'deploymentId': deployment['deploymentId']
+    def deployment_key_create(self, deployment, name='sa-key-1'):
+        key_details = {
+            'deploymentId': deployment['deploymentId'],
+            'keyName': name
         }
 
         # this is the deployment service account endpoint
         resp = requests.post(
             self.url + '/api/v1/auth/keys',
             headers = self.header,
-            json = deployment_id,
+            json = key_details
         )
         resp.raise_for_status()
 

--- a/quickstart/tutorial.md
+++ b/quickstart/tutorial.md
@@ -94,7 +94,7 @@ The script should take approximately 25 minutes to run.
 Region:                   "us-west2"
 Zone:                     "us-west2-b"
 Network:                  "vpc-cas"
-Subnetowrk:               "subnet-ws"
+Subnetwork:               "subnet-ws"
 Domain name:              "example.com"
 Domain service account:   "cam_admin"
 Service account password: <set by you at start of script>


### PR DESCRIPTION
To support autoscaling of CAC's in the future, new CAC tokens need
to be created during CAC installations. To generate new connector
tokens, the CAM python script is used during provisioning of the
connector, which makes CAM API calls using the user-provided CAM
deployment-level service account credentials.

Both plaintext and encrypted secrets deployments are supported using
CAM deployment-level service accounts instead of connector tokens.

Signed-off-by: Edwin-Pau <epau@teradici.com>