### PR TITLE
Update NVIDIA drivers for agent version 20.04

### DIFF
--- a/modules/aws/centos-gfx/vars.tf
+++ b/modules/aws/centos-gfx/vars.tf
@@ -112,7 +112,7 @@ variable "pcoip_agent_repo_url" {
 
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
-  default     = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/grid-9.1/NVIDIA-Linux-x86_64-430.46-grid.run"
+  default     = "https://s3.amazonaws.com/ec2-linux-nvidia-drivers/g4/grid-9.3/NVIDIA-Linux-x86_64-430.83-grid-aws.run"
 }
 
 variable "depends_on_hack" {

--- a/modules/gcp/centos-gfx/vars.tf
+++ b/modules/gcp/centos-gfx/vars.tf
@@ -137,7 +137,7 @@ variable "pcoip_agent_repo_url" {
 
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
-  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID9.1/NVIDIA-Linux-x86_64-430.46-grid.run"
+  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID9.3/NVIDIA-Linux-x86_64-430.83-grid.run"
 }
 
 variable "depends_on_hack" {

--- a/modules/gcp/win-gfx/main.tf
+++ b/modules/gcp/win-gfx/main.tf
@@ -27,6 +27,7 @@ resource "google_storage_bucket_object" "win-gfx-provisioning-script" {
       kms_cryptokey_id            = var.kms_cryptokey_id,
       pcoip_registration_code     = var.pcoip_registration_code,
       nvidia_driver_url           = var.nvidia_driver_url,
+      nvidia_driver_filename      = var.nvidia_driver_filename,
       domain_name                 = var.domain_name,
       admin_password              = var.admin_password,
       ad_service_account_username = var.ad_service_account_username,

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -117,7 +117,7 @@ variable "admin_password" {
 
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
-  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID9.1/431.79_grid_win10_server2016_server2019_64bit_international.exe"
+  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID10.1/442.06_grid_win10_server2016_server2019_64bit_international.exe"
 }
 
 variable "pcoip_agent_location_url" {

--- a/modules/gcp/win-gfx/vars.tf
+++ b/modules/gcp/win-gfx/vars.tf
@@ -117,7 +117,12 @@ variable "admin_password" {
 
 variable "nvidia_driver_url" {
   description = "URL of NVIDIA GRID driver"
-  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID10.1/442.06_grid_win10_server2016_server2019_64bit_international.exe"
+  default     = "https://storage.googleapis.com/nvidia-drivers-us-public/GRID/GRID10.1/"
+}
+
+variable "nvidia_driver_filename" {
+  description = "Filename of NVIDIA GRID driver"
+  default     = "442.06_grid_win10_server2016_server2019_64bit_international.exe"
 }
 
 variable "pcoip_agent_location_url" {

--- a/modules/gcp/win-gfx/win-gfx-provisioning.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-provisioning.ps1.tmpl
@@ -5,8 +5,12 @@
 
 $LOG_FILE = "C:\Teradici\provisioning.log"
 $NVIDIA_DIR = "C:\Program Files\NVIDIA Corporation\NVSMI"
+
 $PCOIP_AGENT_LOCATION_URL = "${pcoip_agent_location_url}"
 $PCOIP_AGENT_FILENAME     = "${pcoip_agent_filename}"
+
+$NVIDIA_DRIVER_URL      = "${nvidia_driver_url}"
+$NVIDIA_DRIVER_FILENAME = "${nvidia_driver_filename}"
 
 $DECRYPT_URI = "https://cloudkms.googleapis.com/v1/${kms_cryptokey_id}:decrypt"
 
@@ -122,11 +126,13 @@ function Nvidia-Install {
 
     mkdir 'C:\Nvidia'
     $driverDirectory = "C:\Nvidia"
-    $nvidiaDriverFileName = Split-Path ${nvidia_driver_url} -Leaf
-    $nvidiaDriverLocation = Split-Path ${nvidia_driver_url} -Parent
-    $destFile = $driverDirectory + "\" + $nvidiaDriverFileName
-    "--> Downloading NVIDIA GRID driver from $nvidiaDriverLocation..."
-    (New-Object System.Net.WebClient).DownloadFile("${nvidia_driver_url}", $destFile)
+
+    $nvidiaInstallerUrl = $NVIDIA_DRIVER_URL + $NVIDIA_DRIVER_FILENAME
+    $destFile = $driverDirectory + "\" + $NVIDIA_DRIVER_FILENAME
+    $wc = New-Object System.Net.WebClient
+
+    "--> Downloading NVIDIA GRID driver from $NVIDIA_DRIVER_URL..."
+    Retry -Action {$wc.DownloadFile($nvidiaInstallerUrl, $destFile)}
     "--> NVIDIA GRID driver downloaded."
 
     "--> Installing NVIDIA GRID Driver..."


### PR DESCRIPTION
Updated AWS and GCP NVIDIA graphics drivers. Windows workstations
have been upgraded to GRID 10.1 and CentOS workstations have been
upgraded to GRID 9.3 as per the PCoIP graphics agent admin guide
for agent version 20.04.

Signed-off-by: Edwin-Pau <epau@teradici.com>