### PR TITLE
GCP: Fix variable reference in idle shutdown

### DIFF
--- a/modules/gcp/win-gfx/win-gfx-provisioning.ps1.tmpl
+++ b/modules/gcp/win-gfx/win-gfx-provisioning.ps1.tmpl
@@ -255,7 +255,7 @@ function Install-Idle-Shutdown {
     $cpuPollingIntervalRegKeyName = "PollingIntervalMinutes"
 
     if (!(Test-Path $idleShutdownRegKeyPath)) {
-        New-Item -Path $idleTimerRegKeyPath -Force
+        New-Item -Path $idleShutdownRegKeyPath -Force
     }
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force

--- a/modules/gcp/win-std/win-std-provisioning.ps1.tmpl
+++ b/modules/gcp/win-std/win-std-provisioning.ps1.tmpl
@@ -206,7 +206,7 @@ function Install-Idle-Shutdown {
     $cpuPollingIntervalRegKeyName = "PollingIntervalMinutes"
 
     if (!(Test-Path $idleShutdownRegKeyPath)) {
-        New-Item -Path $idleTimerRegKeyPath -Force
+        New-Item -Path $idleShutdownRegKeyPath -Force
     }
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $idleTimerRegKeyName -Value $AUTO_SHUTDOWN_IDLE_TIMER -PropertyType DWORD -Force
     New-ItemProperty -Path $idleShutdownRegKeyPath -Name $cpuPollingIntervalRegKeyName -Value $CPU_POLLING_INTERVAL -PropertyType DWORD -Force


### PR DESCRIPTION
Fixed a typo when referencing a variable in the idle shutdown function.
The variable used should be $idleShutdownRegKeyPath and not
$idleTimerRegKeyPath.

Signed-off-by: Edwin-Pau <epau@teradici.com>