### PR TITLE
Add domain name to realm join command

### DIFF
--- a/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
+++ b/modules/aws/centos-gfx/centos-gfx-startup.sh.tmpl
@@ -220,9 +220,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]

--- a/modules/aws/centos-std/centos-std-startup.sh.tmpl
+++ b/modules/aws/centos-std/centos-std-startup.sh.tmpl
@@ -126,9 +126,9 @@ join_domain()
         log "--> Joining the domain"
         if [[ -n "$OU" ]]
         then
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" --computer-ou="$OU" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" --computer-ou="$OU" "${domain_name}" >&2
         else
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" "${domain_name}" >&2
         fi
         exitCode=$?
         if [[ $exitCode -eq 0 ]]

--- a/modules/gcp/centos-gfx/centos-gfx-provisioning.sh.tmpl
+++ b/modules/gcp/centos-gfx/centos-gfx-provisioning.sh.tmpl
@@ -267,7 +267,7 @@ join_domain() {
 
         while true
         do
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" --verbose >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" "${domain_name}" --verbose >&2
             
             local rc=$?
             if [[ $rc -eq 0 ]]

--- a/modules/gcp/centos-std/centos-std-provisioning.sh.tmpl
+++ b/modules/gcp/centos-std/centos-std-provisioning.sh.tmpl
@@ -187,7 +187,7 @@ join_domain() {
 
         while true
         do
-            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}" "${domain_name}" --verbose >&2
+            echo "$AD_SERVICE_ACCOUNT_PASSWORD" | realm join --user="${ad_service_account_username}@${domain_name}" "${domain_name}" --verbose >&2
             
             local rc=$?
             if [[ $rc -eq 0 ]]


### PR DESCRIPTION
When realm joining on CentOS machines, the domain name 
has been added explicitly after the user name.

Signed-off-by: Edwin-Pau <epau@teradici.com>