### PR TITLE
Fix KMS encryption script to run in GCP cloud shell

### DIFF
--- a/docs/README-aws.md
+++ b/docs/README-aws.md
@@ -44,7 +44,7 @@ The following command can be used to decrypt the ciphertext:
 ### Customizing terraform.tfvars
 terraform.tfvars is the file in which a user specify variables for a deployment. In each deployment, there is a ```terraform.tfvars.sample``` file showing the required variables that a user must provide, along with other commonly used but optional variables. Uncommented lines show required variables, while commented lines show optional variables with their default or sample values. A complete list of available variables are described in the variable definition file ```vars.tf``` of the deployment.
 
-Note that all path variables in terraform.tfvars depend on the host platform: 
+Note that all path variables in terraform.tfvars should be absolute paths and they depend on the host platform: 
 - On Linux systems, the forward slash / is used as the path segment separator. ```aws_credentials_file = "/path/to/aws_key"```
 - On Windows systems, the default Windows backslash \ separator must be changed to forward slash as the path segment separator. ```aws_credentials_file = "C:/path/to/aws_key"```
 

--- a/docs/README-gcp.md
+++ b/docs/README-gcp.md
@@ -63,7 +63,7 @@ The script can also reverse the encryption by running with the '-d' flag. See sc
 ### Customizing terraform.tfvars
 terraform.tfvars is the file in which a user specify variables for a deployment. In each deployment, there is a ```terraform.tfvars.sample``` file showing the required variables that a user must provide, along with other commonly used but optional variables. Uncommented lines show required variables, while commented lines show optional variables with their default or sample values. A complete list of available variables are described in the variable definition file ```vars.tf``` of the deployment.
 
-Note that all path variables in terraform.tfvars depend on the host platform: 
+Note that all path variables in terraform.tfvars should be absolute paths and they depend on the host platform: 
 - On Linux systems, the forward slash / is used as the path segment separator. ```gcp_credentials_file = "/path/to/cred.json"```
 - On Windows systems, the default Windows backslash \ separator must be changed to forward slash as the path segment separator. ```gcp_credentials_file = "C:/path/to/cred.json"```
 

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2019 Teradici Corporation
 #
@@ -296,6 +296,8 @@ if __name__ == '__main__':
     kms_python_client_install()
     os.chdir('../')
     os.chdir(DEPLOYMENT_PATH)
+    # Paths passed into terraform.tfvars should be absolute paths
+    cwd = os.getcwd() + '/'
 
     try:
         print('Creating directory {} to store secrets...'.format(SECRETS_DIR))
@@ -378,8 +380,6 @@ if __name__ == '__main__':
     print('Done encrypting secrets.')
 
     print('Deploying with Terraform...')
-    # Paths passed into terraform.tfvars should be absolute paths
-    cwd = os.getcwd() + '/'
 
     #TODO: refactor this to work with more types of deployments
     settings = {

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -378,21 +378,24 @@ if __name__ == '__main__':
     print('Done encrypting secrets.')
 
     print('Deploying with Terraform...')
+    # Paths passed into terraform.tfvars should be absolute paths
+    cwd = os.getcwd() + '/'
+
     #TODO: refactor this to work with more types of deployments
     settings = {
-        'gcp_credentials_file':           SA_KEY_PATH,
+        'gcp_credentials_file':           cwd + SA_KEY_PATH,
         'gcp_project_id':                 PROJECT_ID,
         'gcp_service_account':            sa_email,
         'kms_cryptokey_id':               key_name,
         'dc_admin_password':              password,
         'safe_mode_admin_password':       password,
         'ad_service_account_password':    password,
-        'cac_admin_ssh_pub_key_file':     SSH_KEY_PATH + '.pub',
+        'cac_admin_ssh_pub_key_file':     cwd + SSH_KEY_PATH + '.pub',
         'win_gfx_instance_count':         cfg_data.get('gwin'),
         'win_std_instance_count':         cfg_data.get('swin'),
         'centos_gfx_instance_count':      cfg_data.get('gcent'),
         'centos_std_instance_count':      cfg_data.get('scent'),
-        'centos_admin_ssh_pub_key_file':  SSH_KEY_PATH + '.pub',
+        'centos_admin_ssh_pub_key_file':  cwd + SSH_KEY_PATH + '.pub',
         'pcoip_registration_code':        cfg_data.get('reg_code'),
         'cac_token':                      connector['token'],
     }

--- a/quickstart/tutorial.md
+++ b/quickstart/tutorial.md
@@ -5,7 +5,7 @@ The goal of this tutorial is to create the [single-connector](https://github.com
 
 This tutorial will guide you in entering a few parameters in a configuration file before showing you how to run a Python script in the Cloud Shell to create the Cloud Access Connector deployment.
 
-The Python script is a wrapper script that sets up the environment required for running Terraform scripts, which actually creates the GCP infrasturcture such as Networking and Compute resources.
+The Python script is a wrapper script that sets up the environment required for running Terraform scripts, which actually creates the GCP infrastructure such as Networking and Compute resources.
 
 **Time to complete**: about 30 minutes
 

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -10,7 +10,6 @@ import base64
 import importlib
 import os
 import subprocess
-from google.oauth2   import service_account
 
 
 SECRETS_START_FLAG = "# <-- Start of secrets section, do not edit this line. -->"

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -33,18 +33,18 @@ def import_or_install_module(pip_package, module_name = None):
 
     try:
         module = importlib.import_module(module_name)
-        print("Successfully imported {}.".format(module_name))
+        print(f"Successfully imported {module_name}.")
 
     except ImportError:
-        install_cmd = "pip3 install {} --user".format(pip_package)
+        install_cmd = f"pip3 install {pip_package} --user"
         subprocess.run(install_cmd.split(' '), check=True)
-        print("Successfully installed {}.".format(pip_package))
+        print(f"Successfully installed {pip_package}.")
 
         module = importlib.import_module(module_name)
-        print("Successfully imported {}.".format(module_name))
+        print(f"Successfully imported {module_name}.")
 
     except Exception as err:
-        print("An exception occurred importing {}.".format(module_name))
+        print(f"An exception occurred importing {module_name}.")
         print("{}\n".format(err))
         raise SystemExit()
 
@@ -193,7 +193,7 @@ class Tfvars_Encryptor_GCP:
         """
 
         try:
-            print("Decrypting file: {}...".format(file_path))
+            print(f"Decrypting file: {file_path}...")
 
             with open(file_path) as f:
                 f_ciphertext = f.read()
@@ -201,7 +201,7 @@ class Tfvars_Encryptor_GCP:
             f_plaintext = self.decrypt_ciphertext(f_ciphertext)
 
             # Removes the .encrypted appended using this encryptor
-            file_path_decrypted = "{}.decrypted".format(file_path).replace(".encrypted", "")
+            file_path_decrypted = f"{file_path}.decrypted".replace(".encrypted", "")
 
             with open(file_path_decrypted, "w") as f:
                 f.write(f_plaintext)
@@ -232,7 +232,7 @@ class Tfvars_Encryptor_GCP:
                 if os.path.isfile(self.tfvars_secrets.get(secret)):
                     self.tfvars_secrets[secret] = self.decrypt_file(self.tfvars_secrets.get(secret))
                 else:
-                    print("Decrypting {}...".format(secret))
+                    print(f"Decrypting {secret}...")
                     self.tfvars_secrets[secret] = self.decrypt_ciphertext(self.tfvars_secrets.get(secret))
             
             # Write encrypted secrets into new terraform.tfvars file
@@ -258,13 +258,13 @@ class Tfvars_Encryptor_GCP:
         """
 
         try:
-            print("Encrypting file: {}...".format(file_path))
+            print(f"Encrypting file: {file_path}...")
             
             with open(file_path) as f:
                 f_string = f.read()
 
             f_encrypted_string = self.encrypt_plaintext(f_string)
-            file_path_encrypted = "{}.encrypted".format(file_path).replace(".decrypted", "")
+            file_path_encrypted = f"{file_path}.encrypted".replace(".decrypted", "")
             
             with open(file_path_encrypted, "w") as f:
                 f.write(f_encrypted_string)
@@ -313,7 +313,7 @@ class Tfvars_Encryptor_GCP:
                 if os.path.isfile(self.tfvars_secrets.get(secret)):
                     self.tfvars_secrets[secret] = self.encrypt_file(self.tfvars_secrets.get(secret))
                 else:
-                    print("Encrypting {}...".format(secret))
+                    print(f"Encrypting {secret}...")
                     self.tfvars_secrets[secret] = self.encrypt_plaintext(self.tfvars_secrets.get(secret))
 
             # Write encrypted secrets into new terraform.tfvars file
@@ -345,14 +345,14 @@ class Tfvars_Encryptor_GCP:
         if crypto_key_id not in crypto_keys_list:
             try:
                 self.create_crypto_key(crypto_key_id)
-                print("Created key: {}\n".format(crypto_key_id))
+                print(f"Created key: {crypto_key_id}\n")
                 
             except Exception as err:
                 print("An exception occurred creating new crypto key:")
                 print("{}".format(err))
                 raise SystemExit()
         else:
-            print("Using existing crypto key: {}\n".format(crypto_key_id))
+            print(f"Using existing crypto key: {crypto_key_id}\n")
         
         return crypto_key_id
 
@@ -375,14 +375,14 @@ class Tfvars_Encryptor_GCP:
         if key_ring_id not in key_rings_list:
             try:
                 self.create_key_ring(key_ring_id)
-                print("Created key ring: {}\n".format(key_ring_id))
+                print(f"Created key ring: {key_ring_id}\n")
         
             except Exception as err:
                 print("An exception occurred creating new key ring:")
                 print("{}".format(err))
                 raise SystemExit()
         else: 
-            print("Using existing key ring: {}\n".format(key_ring_id))
+            print(f"Using existing key ring: {key_ring_id}\n")
 
         return key_ring_id
 
@@ -489,9 +489,9 @@ class Tfvars_Encryptor_GCP:
                 # Append the crypto key path to kms_cryptokey_id line
                 if "kms_cryptokey_id =" in line:
                     if not self.tfvars_data.get("kms_cryptokey_id"):
-                        lines.append("{} = \"{}\"".format("kms_cryptokey_id", self.crypto_key_path))
+                        lines.append(f"kms_cryptokey_id = \"{self.crypto_key_path}\"")
                     else:
-                        lines.append("# {} = \"{}\"".format("kms_cryptokey_id", self.crypto_key_path))
+                        lines.append(f"# kms_cryptokey_id = \"{self.crypto_key_path}\"")
                     continue
 
                 # Blank lines and comments are unchanged
@@ -505,13 +505,13 @@ class Tfvars_Encryptor_GCP:
 
                 if key in self.tfvars_secrets.keys():
                     # Left justify all the secrets with space as padding on the right
-                    lines.append("{} = \"{}\"".format(key.ljust(self.max_key_length, " "), self.tfvars_secrets.get(key)))
+                    lines.append(f"{key.ljust(self.max_key_length, ' ')} = \"{self.tfvars_secrets.get(key)}\"")
                 else:
                     lines.append(line)
 
         # Add .backup postfix to the original tfvars file
         print("Creating backup of terraform.tfvars...")
-        os.rename(self.tfvars_path, "{}.backup".format(self.tfvars_path))
+        os.rename(self.tfvars_path, f"{self.tfvars_path}.backup")
 
         # Rewrite the existing terraform.tfvars
         print("Writing new terraform.tfvars...")

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Teradici Corporation
 #

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -7,12 +7,49 @@
 
 import argparse
 import base64
+import importlib
 import os
-from google.cloud    import kms_v1
+import subprocess
 from google.oauth2   import service_account
 
 
 SECRETS_START_FLAG = "# <-- Start of secrets section, do not edit this line. -->"
+
+
+def import_or_install_module(pip_package, module_name = None):
+    """A function that imports a Python top-level package or module. 
+    If the required package is not installed, it will install the package before importing it again.
+
+    Args:
+        pip_package (str): the name of the pip package to be installed
+        module_name (str): the import name of the module if it is different than the pip package name
+
+    Returns:
+        module: the top-level package or module
+    """
+
+    if module_name is None:
+        module_name = pip_package
+
+    try:
+        module = importlib.import_module(module_name)
+        print("Successfully imported {}.".format(module_name))
+
+    except ImportError:
+        install_cmd = "pip3 install {} --user".format(pip_package)
+        subprocess.run(install_cmd.split(' '), check=True)
+        print("Successfully installed {}.".format(pip_package))
+
+        module = importlib.import_module(module_name)
+        print("Successfully imported {}.".format(module_name))
+
+    except Exception as err:
+        print("An exception occurred importing {}.".format(module_name))
+        print("{}\n".format(err))
+        raise SystemExit()
+
+    return module
+
 
 class Tfvars_Encryptor_GCP:
     """Tfvars_Encryptor_GCP is used to automate the encryption or decryption of secrets in a terraform 
@@ -520,5 +557,9 @@ def main():
 
 
 if __name__ == '__main__':
+    # Install and import the required packages and modules
+    kms_v1 = import_or_install_module("google-cloud-kms", "google.cloud.kms_v1")
+    service_account = import_or_install_module("google_oauth2_tool", "google.oauth2.service_account")
+
     main()
 

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -44,9 +44,8 @@ def import_or_install_module(pip_package, module_name = None):
         print(f"Successfully imported {module_name}.")
 
     except Exception as err:
-        print(f"An exception occurred importing {module_name}.")
-        print("{}\n".format(err))
-        raise SystemExit()
+        print(f"An exception occurred importing {module_name}.\n")
+        raise SystemExit(err)
 
     return module
 
@@ -207,9 +206,8 @@ class Tfvars_Encryptor_GCP:
                 f.write(f_plaintext)
 
         except Exception as err:
-            print("An exception occurred decrypting file.")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred decrypting file.\n")
+            raise SystemExit(err)
         
         return file_path_decrypted
 
@@ -240,9 +238,8 @@ class Tfvars_Encryptor_GCP:
             print("\nSuccessfully decrypted all secrets!\n")
 
         except Exception as err:
-            print("An exception occurred decrypting secrets:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred decrypting secrets:\n")
+            raise SystemExit(err)
 
 
     def encrypt_file(self, file_path):
@@ -270,9 +267,8 @@ class Tfvars_Encryptor_GCP:
                 f.write(f_encrypted_string)
 
         except Exception as err:
-            print("An exception occurred encrypting the file:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred encrypting the file:\n")
+            raise SystemExit(err)
         
         return file_path_encrypted
 
@@ -321,9 +317,8 @@ class Tfvars_Encryptor_GCP:
             print("\nSuccessfully encrypted all secrets!\n")
 
         except Exception as err:
-            print("An exception occurred encrypting secrets:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred encrypting secrets:\n")
+            raise SystemExit(err)
 
 
     def initialize_cryptokey(self, crypto_key_id):
@@ -348,9 +343,8 @@ class Tfvars_Encryptor_GCP:
                 print(f"Created key: {crypto_key_id}\n")
                 
             except Exception as err:
-                print("An exception occurred creating new crypto key:")
-                print("{}".format(err))
-                raise SystemExit()
+                print("An exception occurred creating new crypto key:\n")
+                raise SystemExit(err)
         else:
             print(f"Using existing crypto key: {crypto_key_id}\n")
         
@@ -378,9 +372,8 @@ class Tfvars_Encryptor_GCP:
                 print(f"Created key ring: {key_ring_id}\n")
         
             except Exception as err:
-                print("An exception occurred creating new key ring:")
-                print("{}".format(err))
-                raise SystemExit()
+                print("An exception occurred creating new key ring:\n")
+                raise SystemExit(err)
         else: 
             print(f"Using existing key ring: {key_ring_id}\n")
 


### PR DESCRIPTION
Applied several fixes that enable the KMS encryption script under tools to be run from GCP cloud shell directly. A use-case would be if a user wanted to use the script to decrypt the terraform.tfvars file after completing the GCP quickstart deployment. 

Signed-off-by: Edwin-Pau <epau@teradici.com>