### PR TITLE
Fix KMS encryption script to run in GCP cloud shell

### DIFF
--- a/docs/README-aws.md
+++ b/docs/README-aws.md
@@ -44,7 +44,7 @@ The following command can be used to decrypt the ciphertext:
 ### Customizing terraform.tfvars
 terraform.tfvars is the file in which a user specify variables for a deployment. In each deployment, there is a ```terraform.tfvars.sample``` file showing the required variables that a user must provide, along with other commonly used but optional variables. Uncommented lines show required variables, while commented lines show optional variables with their default or sample values. A complete list of available variables are described in the variable definition file ```vars.tf``` of the deployment.
 
-Note that all path variables in terraform.tfvars depend on the host platform: 
+Note that all path variables in terraform.tfvars should be absolute paths and they depend on the host platform: 
 - On Linux systems, the forward slash / is used as the path segment separator. ```aws_credentials_file = "/path/to/aws_key"```
 - On Windows systems, the default Windows backslash \ separator must be changed to forward slash as the path segment separator. ```aws_credentials_file = "C:/path/to/aws_key"```
 

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -91,8 +91,10 @@ Next steps:
      web interface and manually created workstations. Resources not created by
      the Terraform scripts must be manually removed before Terraform can
      properly destroy resources it created.
-  2. In GCP cloudshell, change directory using the command "cd ~/cloud_deployment_scripts/{deployment_path}"
+  2. In GCP cloudshell, change directory using the command "cd ~/cloudshell_open/cloud_deployment_scripts/{deployment_path}"
   3. Remove resources deployed by Terraform using the command "terraform destroy". Enter "yes" when prompted.
+     Note: If Terraform was installed using this quickstart script, execute the following command instead.
+     "~/bin/terraform destroy"
   4. Log in to https://cam.teradici.com and delete the deployment named
      "quickstart_deployment_<timestamp>"
 """

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -297,6 +297,8 @@ if __name__ == '__main__':
     kms_python_client_install()
     os.chdir('../')
     os.chdir(DEPLOYMENT_PATH)
+    # Paths passed into terraform.tfvars should be absolute paths
+    cwd = os.getcwd() + '/'
 
     try:
         print('Creating directory {} to store secrets...'.format(SECRETS_DIR))
@@ -385,21 +387,22 @@ if __name__ == '__main__':
     print('  Key written to ' + CAM_DEPLOYMENT_SA_KEY_PATH)
 
     print('Deploying with Terraform...')
+
     #TODO: refactor this to work with more types of deployments
     settings = {
-        'gcp_credentials_file':           GCP_SA_KEY_PATH,
+        'gcp_credentials_file':           cwd + GCP_SA_KEY_PATH,
         'gcp_project_id':                 PROJECT_ID,
         'gcp_service_account':            sa_email,
         'kms_cryptokey_id':               key_name,
         'dc_admin_password':              password,
         'safe_mode_admin_password':       password,
         'ad_service_account_password':    password,
-        'cac_admin_ssh_pub_key_file':     SSH_KEY_PATH + '.pub',
+        'cac_admin_ssh_pub_key_file':     cwd + SSH_KEY_PATH + '.pub',
         'win_gfx_instance_count':         cfg_data.get('gwin'),
         'win_std_instance_count':         cfg_data.get('swin'),
         'centos_gfx_instance_count':      cfg_data.get('gcent'),
         'centos_std_instance_count':      cfg_data.get('scent'),
-        'centos_admin_ssh_pub_key_file':  SSH_KEY_PATH + '.pub',
+        'centos_admin_ssh_pub_key_file':  cwd + SSH_KEY_PATH + '.pub',
         'pcoip_registration_code':        cfg_data.get('reg_code'),
         'cam_deployment_sa_file':         CAM_DEPLOYMENT_SA_KEY_PATH
     }

--- a/quickstart/gcp-cloudshell-quickstart.py
+++ b/quickstart/gcp-cloudshell-quickstart.py
@@ -1,4 +1,4 @@
-#!/usr/local/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2019 Teradici Corporation
 #

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -20,7 +20,6 @@ TERRAFORM_BIN_PATH = TERRAFORM_BIN_DIR + '/terraform'
 
 
 def terraform_install(version=TERRAFORM_VERSION):
-
     zip_filename = 'terraform_{}_linux_amd64.zip'.format(version)
     download_url = 'https://releases.hashicorp.com/terraform/{}/{}'.format(version, zip_filename)
     local_zip_file = TEMP_DIR + '/' + zip_filename
@@ -55,6 +54,6 @@ if __name__ == '__main__':
     path = shutil.which('terraform')
     if path:
         print('Terraform already installed in ' + path)
-        sys.exit()
+        sys.exit(1)
 
     terraform_install()

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -3,18 +3,24 @@
 # This source code is licensed under the MIT license found in the
 # LICENSE file in the root directory of this source tree.
 
+import argparse
 import os
+import pathlib
 import shutil
 import sys
 import urllib.request
 import zipfile
 
+
 TEMP_DIR           = '/tmp'
 TERRAFORM_VERSION  = '0.12.3'
-TERRAFORM_BIN_DIR  = '/usr/local/bin'
+HOME               = os.path.expanduser('~')
+TERRAFORM_BIN_DIR  = f'{HOME}/bin'
 TERRAFORM_BIN_PATH = TERRAFORM_BIN_DIR + '/terraform'
 
+
 def terraform_install(version=TERRAFORM_VERSION):
+
     zip_filename = 'terraform_{}_linux_amd64.zip'.format(version)
     download_url = 'https://releases.hashicorp.com/terraform/{}/{}'.format(version, zip_filename)
     local_zip_file = TEMP_DIR + '/' + zip_filename
@@ -23,6 +29,7 @@ def terraform_install(version=TERRAFORM_VERSION):
     urllib.request.urlretrieve(download_url, local_zip_file)
 
     print('Extracting to {}...'.format(TERRAFORM_BIN_DIR))
+    pathlib.Path(TERRAFORM_BIN_DIR).mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(local_zip_file) as tf_zip_file:
         tf_zip_file.extractall(TERRAFORM_BIN_DIR)
 
@@ -35,14 +42,19 @@ def terraform_install(version=TERRAFORM_VERSION):
 
 
 if __name__ == '__main__':
+    # Set up argparse
+    parser_description = ('Installs Terraform in the specified directory.')
 
+    parser = argparse.ArgumentParser(description=parser_description)
+    parser.add_argument('dir', help='specify the directory to install Terraform')
+    args = parser.parse_args()
+
+    TERRAFORM_BIN_DIR = args.dir
+
+    # Don't attempt to install unless needed
     path = shutil.which('terraform')
     if path:
         print('Terraform already installed in ' + path)
         sys.exit()
-
-    if os.geteuid() != 0:
-        print('Must run as root to install Terraform.')
-        sys.exit(1)
 
     terraform_install()

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -14,12 +14,9 @@ import zipfile
 
 TEMP_DIR           = '/tmp'
 TERRAFORM_VERSION  = '0.12.3'
-HOME               = os.path.expanduser('~')
-TERRAFORM_BIN_DIR  = f'{HOME}/bin'
-TERRAFORM_BIN_PATH = TERRAFORM_BIN_DIR + '/terraform'
 
 
-def terraform_install(version=TERRAFORM_VERSION):
+def terraform_install(terraform_bin_dir, version=TERRAFORM_VERSION):
     zip_filename = 'terraform_{}_linux_amd64.zip'.format(version)
     download_url = 'https://releases.hashicorp.com/terraform/{}/{}'.format(version, zip_filename)
     local_zip_file = TEMP_DIR + '/' + zip_filename
@@ -27,12 +24,12 @@ def terraform_install(version=TERRAFORM_VERSION):
     print('Downloading from {} to {}...'.format(download_url, local_zip_file))
     urllib.request.urlretrieve(download_url, local_zip_file)
 
-    print('Extracting to {}...'.format(TERRAFORM_BIN_DIR))
-    pathlib.Path(TERRAFORM_BIN_DIR).mkdir(parents=True, exist_ok=True)
+    print('Extracting to {}...'.format(terraform_bin_dir))
+    pathlib.Path(terraform_bin_dir).mkdir(parents=True, exist_ok=True)
     with zipfile.ZipFile(local_zip_file) as tf_zip_file:
-        tf_zip_file.extractall(TERRAFORM_BIN_DIR)
+        tf_zip_file.extractall(terraform_bin_dir)
 
-    os.chmod(TERRAFORM_BIN_PATH, 0o775)
+    os.chmod(terraform_bin_dir + '/terraform', 0o775)
 
     print('Deleting {}...'.format(local_zip_file))
     os.remove(local_zip_file)
@@ -48,12 +45,10 @@ if __name__ == '__main__':
     parser.add_argument('dir', help='specify the directory to install Terraform')
     args = parser.parse_args()
 
-    TERRAFORM_BIN_DIR = args.dir
-
     # Don't attempt to install unless needed
     path = shutil.which('terraform')
     if path:
         print('Terraform already installed in ' + path)
         sys.exit(1)
 
-    terraform_install()
+    terraform_install(args.dir)

--- a/quickstart/tutorial.md
+++ b/quickstart/tutorial.md
@@ -114,5 +114,10 @@ cd ../deployments/gcp/single-connector
 ```bash
 terraform destroy
 ```
+  Note: If Terraform was installed using this quickstart script, execute the following command instead.
+```bash
+~/bin/terraform destroy
+```
+
   4. Log in to [https://cam.teradici.com](https://cam.teradici.com) and delete the deployment named
      **`quickstart_deployment_<timestamp>`**

--- a/quickstart/tutorial.md
+++ b/quickstart/tutorial.md
@@ -5,7 +5,7 @@ The goal of this tutorial is to create the [single-connector](https://github.com
 
 This tutorial will guide you in entering a few parameters in a configuration file before showing you how to run a Python script in the Cloud Shell to create the Cloud Access Connector deployment.
 
-The Python script is a wrapper script that sets up the environment required for running Terraform scripts, which actually creates the GCP infrasturcture such as Networking and Compute resources.
+The Python script is a wrapper script that sets up the environment required for running Terraform scripts, which actually creates the GCP infrastructure such as Networking and Compute resources.
 
 **Time to complete**: about 30 minutes
 

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -16,20 +16,20 @@ import sys
 SECRETS_START_FLAG = "# <-- Start of secrets section, do not edit this line. -->"
 
 
-def import_or_install_module(pip_package_name, module_name = None):
+def import_or_install_module(pypi_package_name, module_name = None):
     """A function that imports a Python top-level package or module. 
     If the required package is not installed, it will install the package before importing it again.
 
     Args:
-        pip_package_name (str): the name of the pip package to be installed
-        module_name (str): the import name of the module if it is different than the pip package name
+        pypi_package_name (str): the name of the PyPI package to be installed
+        module_name (str): the import name of the module if it is different than the PyPI package name
 
     Returns:
         module: the top-level package or module
     """
 
     if module_name is None:
-        module_name = pip_package_name
+        module_name = pypi_package_name
 
     try:
         module = importlib.import_module(module_name)
@@ -37,17 +37,17 @@ def import_or_install_module(pip_package_name, module_name = None):
 
     except ImportError:
         install_permission = input(
-            f"This script requires {pip_package_name} but it is not installed.\n"
-            f"Proceed to install this package by running 'python3 -m pip install {pip_package_name} --user' (y/N)? ").strip().lower()
+            f"This script requires {pypi_package_name} but it is not installed.\n"
+            f"Proceed to install this package by running '{sys.executable} -m pip install {pypi_package_name} --user' (y/n)? ").strip().lower()
 
         if install_permission not in ('y', 'yes'):
-            print(f"{pip_package_name} is not installed. Exiting...")
+            print(f"{pypi_package_name} is not installed. Exiting...")
             sys.exit(1)
 
-        install_cmd = f'{sys.executable} -m pip install {pip_package_name} --user'
+        install_cmd = f'{sys.executable} -m pip install {pypi_package_name} --user'
         subprocess.check_call(install_cmd.split(' '))
 
-        print(f"Successfully installed {pip_package_name}.")
+        print(f"Successfully installed {pypi_package_name}.")
 
         # Recommended to clear cache after installing python packages for dynamic imports
         importlib.invalidate_caches()

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -10,7 +10,6 @@ import base64
 import importlib
 import os
 import subprocess
-from google.oauth2   import service_account
 
 
 SECRETS_START_FLAG = "# <-- Start of secrets section, do not edit this line. -->"

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -33,18 +33,18 @@ def import_or_install_module(pip_package, module_name = None):
 
     try:
         module = importlib.import_module(module_name)
-        print("Successfully imported {}.".format(module_name))
+        print(f"Successfully imported {module_name}.")
 
     except ImportError:
-        install_cmd = "pip3 install {} --user".format(pip_package)
+        install_cmd = f"pip3 install {pip_package} --user"
         subprocess.run(install_cmd.split(' '), check=True)
-        print("Successfully installed {}.".format(pip_package))
+        print(f"Successfully installed {pip_package}.")
 
         module = importlib.import_module(module_name)
-        print("Successfully imported {}.".format(module_name))
+        print(f"Successfully imported {module_name}.")
 
     except Exception as err:
-        print("An exception occurred importing {}.".format(module_name))
+        print(f"An exception occurred importing {module_name}.")
         print("{}\n".format(err))
         raise SystemExit()
 
@@ -193,7 +193,7 @@ class Tfvars_Encryptor_GCP:
         """
 
         try:
-            print("Decrypting file: {}...".format(file_path))
+            print(f"Decrypting file: {file_path}...")
 
             with open(file_path) as f:
                 f_ciphertext = f.read()
@@ -201,7 +201,7 @@ class Tfvars_Encryptor_GCP:
             f_plaintext = self.decrypt_ciphertext(f_ciphertext)
 
             # Removes the .encrypted appended using this encryptor
-            file_path_decrypted = "{}.decrypted".format(file_path).replace(".encrypted", "")
+            file_path_decrypted = f"{file_path}.decrypted".replace(".encrypted", "")
 
             with open(file_path_decrypted, "w") as f:
                 f.write(f_plaintext)
@@ -232,7 +232,7 @@ class Tfvars_Encryptor_GCP:
                 if os.path.isfile(self.tfvars_secrets.get(secret)):
                     self.tfvars_secrets[secret] = self.decrypt_file(self.tfvars_secrets.get(secret))
                 else:
-                    print("Decrypting {}...".format(secret))
+                    print(f"Decrypting {secret}...")
                     self.tfvars_secrets[secret] = self.decrypt_ciphertext(self.tfvars_secrets.get(secret))
             
             # Write encrypted secrets into new terraform.tfvars file
@@ -258,13 +258,13 @@ class Tfvars_Encryptor_GCP:
         """
 
         try:
-            print("Encrypting file: {}...".format(file_path))
+            print(f"Encrypting file: {file_path}...")
             
             with open(file_path) as f:
                 f_string = f.read()
 
             f_encrypted_string = self.encrypt_plaintext(f_string)
-            file_path_encrypted = "{}.encrypted".format(file_path).replace(".decrypted", "")
+            file_path_encrypted = f"{file_path}.encrypted".replace(".decrypted", "")
             
             with open(file_path_encrypted, "w") as f:
                 f.write(f_encrypted_string)
@@ -313,7 +313,7 @@ class Tfvars_Encryptor_GCP:
                 if os.path.isfile(self.tfvars_secrets.get(secret)):
                     self.tfvars_secrets[secret] = self.encrypt_file(self.tfvars_secrets.get(secret))
                 else:
-                    print("Encrypting {}...".format(secret))
+                    print(f"Encrypting {secret}...")
                     self.tfvars_secrets[secret] = self.encrypt_plaintext(self.tfvars_secrets.get(secret))
 
             # Write encrypted secrets into new terraform.tfvars file
@@ -345,14 +345,14 @@ class Tfvars_Encryptor_GCP:
         if crypto_key_id not in crypto_keys_list:
             try:
                 self.create_crypto_key(crypto_key_id)
-                print("Created key: {}\n".format(crypto_key_id))
+                print(f"Created key: {crypto_key_id}\n")
                 
             except Exception as err:
                 print("An exception occurred creating new crypto key:")
                 print("{}".format(err))
                 raise SystemExit()
         else:
-            print("Using existing crypto key: {}\n".format(crypto_key_id))
+            print(f"Using existing crypto key: {crypto_key_id}\n")
         
         return crypto_key_id
 
@@ -375,14 +375,14 @@ class Tfvars_Encryptor_GCP:
         if key_ring_id not in key_rings_list:
             try:
                 self.create_key_ring(key_ring_id)
-                print("Created key ring: {}\n".format(key_ring_id))
+                print(f"Created key ring: {key_ring_id}\n")
         
             except Exception as err:
                 print("An exception occurred creating new key ring:")
                 print("{}".format(err))
                 raise SystemExit()
         else: 
-            print("Using existing key ring: {}\n".format(key_ring_id))
+            print(f"Using existing key ring: {key_ring_id}\n")
 
         return key_ring_id
 
@@ -489,9 +489,9 @@ class Tfvars_Encryptor_GCP:
                 # Append the crypto key path to kms_cryptokey_id line
                 if "kms_cryptokey_id =" in line:
                     if not self.tfvars_data.get("kms_cryptokey_id"):
-                        lines.append("{} = \"{}\"".format("kms_cryptokey_id", self.crypto_key_path))
+                        lines.append(f"kms_cryptokey_id = \"{self.crypto_key_path}\"")
                     else:
-                        lines.append("# {} = \"{}\"".format("kms_cryptokey_id", self.crypto_key_path))
+                        lines.append(f"# kms_cryptokey_id = \"{self.crypto_key_path}\"")
                     continue
 
                 # Blank lines and comments are unchanged
@@ -505,13 +505,13 @@ class Tfvars_Encryptor_GCP:
 
                 if key in self.tfvars_secrets.keys():
                     # Left justify all the secrets with space as padding on the right
-                    lines.append("{} = \"{}\"".format(key.ljust(self.max_key_length, " "), self.tfvars_secrets.get(key)))
+                    lines.append(f"{key.ljust(self.max_key_length, ' ')} = \"{self.tfvars_secrets.get(key)}\"")
                 else:
                     lines.append(line)
 
         # Add .backup postfix to the original tfvars file
         print("Creating backup of terraform.tfvars...")
-        os.rename(self.tfvars_path, "{}.backup".format(self.tfvars_path))
+        os.rename(self.tfvars_path, f"{self.tfvars_path}.backup")
 
         # Rewrite the existing terraform.tfvars
         print("Writing new terraform.tfvars...")

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 # Copyright (c) 2020 Teradici Corporation
 #

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -7,12 +7,49 @@
 
 import argparse
 import base64
+import importlib
 import os
-from google.cloud    import kms_v1
+import subprocess
 from google.oauth2   import service_account
 
 
 SECRETS_START_FLAG = "# <-- Start of secrets section, do not edit this line. -->"
+
+
+def import_or_install_module(pip_package, module_name = None):
+    """A function that imports a Python top-level package or module. 
+    If the required package is not installed, it will install the package before importing it again.
+
+    Args:
+        pip_package (str): the name of the pip package to be installed
+        module_name (str): the import name of the module if it is different than the pip package name
+
+    Returns:
+        module: the top-level package or module
+    """
+
+    if module_name is None:
+        module_name = pip_package
+
+    try:
+        module = importlib.import_module(module_name)
+        print("Successfully imported {}.".format(module_name))
+
+    except ImportError:
+        install_cmd = "pip3 install {} --user".format(pip_package)
+        subprocess.run(install_cmd.split(' '), check=True)
+        print("Successfully installed {}.".format(pip_package))
+
+        module = importlib.import_module(module_name)
+        print("Successfully imported {}.".format(module_name))
+
+    except Exception as err:
+        print("An exception occurred importing {}.".format(module_name))
+        print("{}\n".format(err))
+        raise SystemExit()
+
+    return module
+
 
 class Tfvars_Encryptor_GCP:
     """Tfvars_Encryptor_GCP is used to automate the encryption or decryption of secrets in a terraform 
@@ -520,5 +557,9 @@ def main():
 
 
 if __name__ == '__main__':
+    # Install and import the required packages and modules
+    kms_v1 = import_or_install_module("google-cloud-kms", "google.cloud.kms_v1")
+    service_account = import_or_install_module("google_oauth2_tool", "google.oauth2.service_account")
+
     main()
 

--- a/tools/kms_secrets_encryption.py
+++ b/tools/kms_secrets_encryption.py
@@ -44,9 +44,8 @@ def import_or_install_module(pip_package, module_name = None):
         print(f"Successfully imported {module_name}.")
 
     except Exception as err:
-        print(f"An exception occurred importing {module_name}.")
-        print("{}\n".format(err))
-        raise SystemExit()
+        print(f"An exception occurred importing {module_name}.\n")
+        raise SystemExit(err)
 
     return module
 
@@ -207,9 +206,8 @@ class Tfvars_Encryptor_GCP:
                 f.write(f_plaintext)
 
         except Exception as err:
-            print("An exception occurred decrypting file.")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred decrypting file.\n")
+            raise SystemExit(err)
         
         return file_path_decrypted
 
@@ -240,9 +238,8 @@ class Tfvars_Encryptor_GCP:
             print("\nSuccessfully decrypted all secrets!\n")
 
         except Exception as err:
-            print("An exception occurred decrypting secrets:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred decrypting secrets:\n")
+            raise SystemExit(err)
 
 
     def encrypt_file(self, file_path):
@@ -270,9 +267,8 @@ class Tfvars_Encryptor_GCP:
                 f.write(f_encrypted_string)
 
         except Exception as err:
-            print("An exception occurred encrypting the file:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred encrypting the file:\n")
+            raise SystemExit(err)
         
         return file_path_encrypted
 
@@ -321,9 +317,8 @@ class Tfvars_Encryptor_GCP:
             print("\nSuccessfully encrypted all secrets!\n")
 
         except Exception as err:
-            print("An exception occurred encrypting secrets:")
-            print("{}\n".format(err))
-            raise SystemExit()
+            print("An exception occurred encrypting secrets:\n")
+            raise SystemExit(err)
 
 
     def initialize_cryptokey(self, crypto_key_id):
@@ -348,9 +343,8 @@ class Tfvars_Encryptor_GCP:
                 print(f"Created key: {crypto_key_id}\n")
                 
             except Exception as err:
-                print("An exception occurred creating new crypto key:")
-                print("{}".format(err))
-                raise SystemExit()
+                print("An exception occurred creating new crypto key:\n")
+                raise SystemExit(err)
         else:
             print(f"Using existing crypto key: {crypto_key_id}\n")
         
@@ -378,9 +372,8 @@ class Tfvars_Encryptor_GCP:
                 print(f"Created key ring: {key_ring_id}\n")
         
             except Exception as err:
-                print("An exception occurred creating new key ring:")
-                print("{}".format(err))
-                raise SystemExit()
+                print("An exception occurred creating new key ring:\n")
+                raise SystemExit(err)
         else: 
             print(f"Using existing key ring: {key_ring_id}\n")
 


### PR DESCRIPTION
Applied several fixes that enable the KMS encryption script under tools to be run from GCP cloud shell directly. A use-case would be if a user wanted to use the script to decrypt the terraform.tfvars file after completing the GCP quickstart deployment.

Signed-off-by: Edwin-Pau epau@teradici.com