### PR TITLE
AWS: Updated terraform version from 0.12 to 0.13

### DIFF
--- a/docs/README-aws.md
+++ b/docs/README-aws.md
@@ -35,7 +35,7 @@ Before starting, consider watching [this video](https://www.youtube.com/watch?v=
 - a PCoIP License Server Activation Code is needed for Local License Server (LLS) based deployments.
 - an SSH private / public key pair is required for Terraform to log into Linux hosts. Please visit [ssh-key-pair-setup.md](/docs/ssh-key-pair-setup.md) for instructions.
 - if SSL is involved, the SSL key and certificate files are needed in PEM format.
-- Terraform v0.12.x or higher must be installed. Please download Terraform from https://www.terraform.io/downloads.html
+- Terraform v0.13 or higher must be installed. Please download Terraform from https://www.terraform.io/downloads.html
 
 ### AWS Setup
 Although it is possible to create deployments in existing and currently in-use accounts, it is recommended to create them in new accounts to reduce chances of name collisions and interfering with operations of existing resources.

--- a/modules/aws/cac/versions.tf
+++ b/modules/aws/cac/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/centos-gfx/versions.tf
+++ b/modules/aws/centos-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/centos-std/versions.tf
+++ b/modules/aws/centos-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/dc/versions.tf
+++ b/modules/aws/dc/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/ha-lls/versions.tf
+++ b/modules/aws/ha-lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/lls/versions.tf
+++ b/modules/aws/lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/win-gfx/versions.tf
+++ b/modules/aws/win-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }

--- a/modules/aws/win-std/versions.tf
+++ b/modules/aws/win-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.12"
+  required_version = ">= 0.13"
 }


### PR DESCRIPTION
Regular testing are now performed with Terraform 0.13, hence updating the required version to indicate the version tested with.