### PR TITLE
Osupdate version interpolation

### DIFF
--- a/deployments/gcp/dc-only/main.tf
+++ b/deployments/gcp/dc-only/main.tf
@@ -40,10 +40,10 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-dns.name}",
-    "${google_compute_firewall.allow-rdp.name}",
-    "${google_compute_firewall.allow-winrm.name}",
-    "${google_compute_firewall.allow-icmp.name}",
+    google_compute_firewall.allow-dns.name,
+    google_compute_firewall.allow-rdp.name,
+    google_compute_firewall.allow-winrm.name,
+    google_compute_firewall.allow-icmp.name,
   ]
 
   machine_type = var.dc_machine_type

--- a/deployments/gcp/dc-only/versions.tf
+++ b/deployments/gcp/dc-only/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/deployments/gcp/multi-region/main.tf
+++ b/deployments/gcp/multi-region/main.tf
@@ -40,10 +40,10 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-google-dns.name}",
-    "${google_compute_firewall.allow-rdp.name}",
-    "${google_compute_firewall.allow-winrm.name}",
-    "${google_compute_firewall.allow-icmp.name}",
+    google_compute_firewall.allow-google-dns.name,
+    google_compute_firewall.allow-rdp.name,
+    google_compute_firewall.allow-winrm.name,
+    google_compute_firewall.allow-icmp.name,
   ]
 
   machine_type = var.dc_machine_type
@@ -68,15 +68,15 @@ module "cac-igm" {
   ad_service_account_username = var.ad_service_account_username
   ad_service_account_password = var.ad_service_account_password
 
-  #gcp_region   = "${var.gcp_region}"
+  #gcp_region   = var.gcp_region
   bucket_name   = google_storage_bucket.scripts.name
   gcp_zone_list = var.cac_zone_list
   subnet_list   = google_compute_subnetwork.cac-subnets[*].self_link
   network_tags  = [
-    "${google_compute_firewall.allow-google-health-check.name}",
-    "${google_compute_firewall.allow-ssh.name}",
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-pcoip.name}",
+    google_compute_firewall.allow-google-health-check.name,
+    google_compute_firewall.allow-ssh.name,
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-pcoip.name,
   ]
 
   instance_count_list = var.cac_instance_count_list
@@ -195,8 +195,8 @@ module "win-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = var.win_gfx_instance_count_list
@@ -235,8 +235,8 @@ module "win-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = var.win_std_instance_count_list
@@ -273,8 +273,8 @@ module "centos-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = var.centos_gfx_instance_count_list
@@ -316,8 +316,8 @@ module "centos-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = var.centos_std_instance_count_list

--- a/deployments/gcp/multi-region/output.tf
+++ b/deployments/gcp/multi-region/output.tf
@@ -14,7 +14,7 @@ output "domain-controller-public-ip" {
 }
 
 output "cac-load-balancer-ip" {
-  #value = "${data.google_compute_forwarding_rule.cac-fwdrule.ip_address}"
+  #value = data.google_compute_forwarding_rule.cac-fwdrule.ip_address
   value = google_compute_global_forwarding_rule.cac-fwdrule.ip_address
 }
 

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -82,11 +82,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -46,7 +46,7 @@ cac_instance_count_list = []
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -150,7 +150,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -331,7 +331,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_std_instance_count_list" {
@@ -356,7 +356,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/multi-region/versions.tf
+++ b/deployments/gcp/multi-region/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/deployments/gcp/nlb-multi-region/main.tf
+++ b/deployments/gcp/nlb-multi-region/main.tf
@@ -42,10 +42,10 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-google-dns.name}",
-    "${google_compute_firewall.allow-rdp.name}",
-    "${google_compute_firewall.allow-winrm.name}",
-    "${google_compute_firewall.allow-icmp.name}",
+    google_compute_firewall.allow-google-dns.name,
+    google_compute_firewall.allow-rdp.name,
+    google_compute_firewall.allow-winrm.name,
+    google_compute_firewall.allow-icmp.name,
   ]
 
   machine_type = var.dc_machine_type
@@ -76,9 +76,9 @@ module "cac" {
   subnet_list            = google_compute_subnetwork.cac-subnets[*].self_link
   external_pcoip_ip_list = google_compute_address.nlb-ip[*].address
   network_tags      = [
-    "${google_compute_firewall.allow-ssh.name}",
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-pcoip.name}",
+    google_compute_firewall.allow-ssh.name,
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-pcoip.name,
   ]
 
   instance_count_list = var.cac_instance_count_list
@@ -179,8 +179,8 @@ module "win-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = var.win_gfx_instance_count_list
@@ -219,8 +219,8 @@ module "win-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = var.win_std_instance_count_list
@@ -257,8 +257,8 @@ module "centos-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = var.centos_gfx_instance_count_list
@@ -300,8 +300,8 @@ module "centos-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = var.centos_std_instance_count_list

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -44,7 +44,7 @@ cac_instance_count_list = []
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -80,11 +80,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -326,7 +326,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_std_instance_count_list" {
@@ -351,7 +351,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -145,7 +145,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/nlb-multi-region/versions.tf
+++ b/deployments/gcp/nlb-multi-region/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/deployments/gcp/single-connector/main.tf
+++ b/deployments/gcp/single-connector/main.tf
@@ -40,10 +40,10 @@ module "dc" {
   subnet       = google_compute_subnetwork.dc-subnet.self_link
   private_ip   = var.dc_private_ip
   network_tags = [
-    "${google_compute_firewall.allow-google-dns.name}",
-    "${google_compute_firewall.allow-rdp.name}",
-    "${google_compute_firewall.allow-winrm.name}",
-    "${google_compute_firewall.allow-icmp.name}",
+    google_compute_firewall.allow-google-dns.name,
+    google_compute_firewall.allow-rdp.name,
+    google_compute_firewall.allow-winrm.name,
+    google_compute_firewall.allow-icmp.name,
   ]
 
   machine_type = var.dc_machine_type
@@ -72,9 +72,9 @@ module "cac" {
   gcp_region_list = [var.gcp_region]
   subnet_list     = [google_compute_subnetwork.cac-subnet.self_link]
   network_tags    = [
-    "${google_compute_firewall.allow-ssh.name}",
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-pcoip.name}",
+    google_compute_firewall.allow-ssh.name,
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-pcoip.name,
   ]
 
   instance_count_list = [var.cac_instance_count]
@@ -115,8 +115,8 @@ module "win-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = [var.win_gfx_instance_count]
@@ -155,8 +155,8 @@ module "win-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-rdp.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-rdp.name,
   ]
 
   instance_count_list = [var.win_std_instance_count]
@@ -193,8 +193,8 @@ module "centos-gfx" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = [var.centos_gfx_instance_count]
@@ -236,8 +236,8 @@ module "centos-std" {
   minutes_cpu_polling_interval     = var.minutes_cpu_polling_interval
 
   network_tags     = [
-    "${google_compute_firewall.allow-icmp.name}",
-    "${google_compute_firewall.allow-ssh.name}",
+    google_compute_firewall.allow-icmp.name,
+    google_compute_firewall.allow-ssh.name,
   ]
 
   instance_count_list = [var.centos_std_instance_count]

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -30,7 +30,7 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 
 # Optional: Specify SSL certificate for Connector
 # ssl_key  = "/path/to/privkey.pem"

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -55,12 +55,12 @@ centos_gfx_instance_count = 0
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20200910"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -301,7 +301,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_std_instance_count" {
@@ -326,7 +326,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20200910"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -114,7 +114,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20200923"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201014"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/versions.tf
+++ b/deployments/gcp/single-connector/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/cac-igm/main.tf
+++ b/modules/gcp/cac-igm/main.tf
@@ -133,7 +133,7 @@ resource "google_compute_instance_group_manager" "cac-igm" {
   name = "${local.prefix}igm-cac"
 
   # TODO: makes more sense to use regional IGM
-  #region = "${var.gcp_region}"
+  #region = var.gcp_region
   zone = var.gcp_zone_list[count.index]
 
   base_instance_name = "${local.prefix}cac"

--- a/modules/gcp/cac-igm/versions.tf
+++ b/modules/gcp/cac-igm/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/cac-regional/versions.tf
+++ b/modules/gcp/cac-regional/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/cac/versions.tf
+++ b/modules/gcp/cac/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/centos-gfx/versions.tf
+++ b/modules/gcp/centos-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/centos-std/versions.tf
+++ b/modules/gcp/centos-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/dc/versions.tf
+++ b/modules/gcp/dc/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/win-gfx/versions.tf
+++ b/modules/gcp/win-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 }

--- a/modules/gcp/win-std/versions.tf
+++ b/modules/gcp/win-std/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.13.4"
 
   required_providers {
     google = "~> 2.19.0"

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -13,7 +13,7 @@ import zipfile
 
 
 TEMP_DIR           = '/tmp'
-TERRAFORM_VERSION  = '0.13.3'
+TERRAFORM_VERSION  = '0.13.4'
 
 
 def terraform_install(terraform_bin_dir, version):


### PR DESCRIPTION
We have made following changes:

1. From Terraform version(0.13) to Terraform version version(0.13.4).
2. Removed interpolation syntax.
3. Updated Ubuntuos from "ubuntu-1804-bionic-v20200923" to "ubuntu-1804-bionic-v20201014".
4. Updated Centos from "centos-7-v20200910" to "centos-7-v20201014".