### PR TITLE
GCP: updated WindowsOS in var.tf and .tfvars files

### DIFF
--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "dc_admin_password" {

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -72,11 +72,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "dc_admin_password" {
@@ -271,7 +271,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "win_std_instance_count_list" {
@@ -296,7 +296,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -70,11 +70,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "dc_admin_password" {
@@ -266,7 +266,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "win_std_instance_count_list" {
@@ -291,7 +291,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -43,12 +43,12 @@ win_gfx_instance_count = 0
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "dc_admin_password" {
@@ -241,7 +241,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "win_std_instance_count" {
@@ -266,7 +266,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20200908"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
 }
 
 variable "centos_gfx_instance_count" {


### PR DESCRIPTION
Updated Windows OS version from "windows-server-2019-dc-v20200908" to "windows-server-2019-dc-v20201013".