### PR TITLE
Terraform version update

### DIFF
--- a/deployments/aws/lb-connectors-ha-lls/versions.tf
+++ b/deployments/aws/lb-connectors-ha-lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/deployments/aws/lb-connectors-lls/versions.tf
+++ b/deployments/aws/lb-connectors-lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/deployments/aws/lb-connectors/versions.tf
+++ b/deployments/aws/lb-connectors/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/deployments/aws/single-connector/versions.tf
+++ b/deployments/aws/single-connector/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/deployments/gcp/dc-only/versions.tf
+++ b/deployments/gcp/dc-only/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 
   required_providers {
     google = ">= 3.43.0"

--- a/deployments/gcp/multi-region/versions.tf
+++ b/deployments/gcp/multi-region/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 
   required_providers {
     google = ">= 3.43.0"

--- a/deployments/gcp/nlb-multi-region/versions.tf
+++ b/deployments/gcp/nlb-multi-region/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 
   required_providers {
     google = ">= 3.43.0"

--- a/deployments/gcp/single-connector/versions.tf
+++ b/deployments/gcp/single-connector/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 
   required_providers {
     google = ">= 3.43.0"

--- a/modules/aws/cac/versions.tf
+++ b/modules/aws/cac/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/centos-gfx/versions.tf
+++ b/modules/aws/centos-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/centos-std/versions.tf
+++ b/modules/aws/centos-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/dc/versions.tf
+++ b/modules/aws/dc/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/ha-lls/versions.tf
+++ b/modules/aws/ha-lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/lls/versions.tf
+++ b/modules/aws/lls/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/win-gfx/versions.tf
+++ b/modules/aws/win-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/aws/win-std/versions.tf
+++ b/modules/aws/win-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/cac-igm/versions.tf
+++ b/modules/gcp/cac-igm/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/cac-regional/versions.tf
+++ b/modules/gcp/cac-regional/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/cac/versions.tf
+++ b/modules/gcp/cac/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/centos-gfx/versions.tf
+++ b/modules/gcp/centos-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/centos-std/versions.tf
+++ b/modules/gcp/centos-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/dc/versions.tf
+++ b/modules/gcp/dc/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/win-gfx/versions.tf
+++ b/modules/gcp/win-gfx/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/modules/gcp/win-std/versions.tf
+++ b/modules/gcp/win-std/versions.tf
@@ -6,5 +6,5 @@
  */
 
 terraform {
-  required_version = ">= 0.13.4"
+  required_version = ">= 0.13.5"
 }

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -13,7 +13,7 @@ import zipfile
 
 
 TEMP_DIR           = '/tmp'
-TERRAFORM_VERSION  = '0.13.4'
+TERRAFORM_VERSION  = '0.13.5'
 
 
 def terraform_install(terraform_bin_dir, version):


### PR DESCRIPTION
 Updated terraform version from 0.13.4 to 0.13.5 for both AWS and GCP.

