### PR TITLE
Gcp os update

### DIFF
--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "dc_admin_password" {

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -46,7 +46,7 @@ cac_instance_count_list = []
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -72,11 +72,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -82,11 +82,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "dc_admin_password" {
@@ -271,7 +271,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "win_std_instance_count_list" {
@@ -296,7 +296,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -150,7 +150,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -331,7 +331,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_std_instance_count_list" {
@@ -356,7 +356,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -70,11 +70,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 # centos_gfx_machine_type = "n1-standard-2"
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -80,11 +80,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -44,7 +44,7 @@ cac_instance_count_list = []
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 
 cac_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -326,7 +326,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_std_instance_count_list" {
@@ -351,7 +351,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "dc_admin_password" {
@@ -266,7 +266,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "win_std_instance_count_list" {
@@ -291,7 +291,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -145,7 +145,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -55,12 +55,12 @@ centos_gfx_instance_count = 0
 # centos_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb = 50
-# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_gfx_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201014"
+# centos_std_disk_image = "projects/centos-cloud/global/images/centos-7-v20201112"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -43,12 +43,12 @@ win_gfx_instance_count = 0
 # win_gfx_accelerator_type = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb = 50
-# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_gfx_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+# win_std_disk_image = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 
 centos_gfx_instance_count = 0
 # centos_gfx_machine_type = "n1-standard-2"

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -30,7 +30,7 @@ gcp_service_account  = "service_account_name@<project_id>.iam.gserviceaccount.co
 
 # cac_machine_type = "n1-standard-2"
 # cac_disk_size_gb = 50
-# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+# cac_disk_image = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 
 # Optional: Specify SSL certificate for Connector
 # ssl_key  = "/path/to/privkey.pem"

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -301,7 +301,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_std_instance_count" {
@@ -326,7 +326,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20201014"
+  default     = "projects/centos-cloud/global/images/centos-7-v20201112"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -114,7 +114,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201111"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20201116"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -79,7 +79,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "dc_admin_password" {
@@ -241,7 +241,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "win_std_instance_count" {
@@ -266,7 +266,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201013"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201110"
 }
 
 variable "centos_gfx_instance_count" {


### PR DESCRIPTION
GCP OS update
Updated Ubuntu OS from ubuntu-1804-bionic-v20201111 to ubuntu-1804-bionic-v20201116
Updated CentOS from centos-7-v20201014 to centos-7-v20201112
Updated Windows OS from windows-server-2019-dc-v20201013 to windows-server-2019-dc-v20201110 