### PR TITLE
AWS: Updated Ubuntuos in vars.tf file

### DIFF
--- a/deployments/aws/lb-connectors-ha-lls/vars.tf
+++ b/deployments/aws/lb-connectors-ha-lls/vars.tf
@@ -227,7 +227,7 @@ variable "cac_ami_owner" {
 
 variable "cac_ami_name" {
   description = "Name of the AMI to create Cloud Access Connector from"
-  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201112"
+  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201123"
 }
 
 variable "admin_ssh_key_name" {

--- a/deployments/aws/lb-connectors-lls/vars.tf
+++ b/deployments/aws/lb-connectors-lls/vars.tf
@@ -205,7 +205,7 @@ variable "cac_ami_owner" {
 
 variable "cac_ami_name" {
   description = "Name of the AMI to create Cloud Access Connector from"
-  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201112"
+  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201123"
 }
 
 variable "admin_ssh_key_name" {

--- a/deployments/aws/lb-connectors/vars.tf
+++ b/deployments/aws/lb-connectors/vars.tf
@@ -150,7 +150,7 @@ variable "cac_ami_owner" {
 
 variable "cac_ami_name" {
   description = "Name of the AMI to create Cloud Access Connector from"
-  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201112"
+  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201123"
 }
 
 variable "admin_ssh_key_name" {

--- a/deployments/aws/single-connector/vars.tf
+++ b/deployments/aws/single-connector/vars.tf
@@ -145,7 +145,7 @@ variable "cac_ami_owner" {
 
 variable "cac_ami_name" {
   description = "Name of the AMI to create Cloud Access Connector from"
-  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201112"
+  default = "ubuntu/images/hvm-ssd/ubuntu-bionic-18.04-amd64-server-20201123"
 }
 
 variable "admin_ssh_key_name" {


### PR DESCRIPTION
Updated Ubuntu OS from "ubuntu-bionic-18.04-amd64-server-20201112" to "ubuntu-bionic-18.04-amd64-server-20201123" in all required files for AWS deployments.