### PR TITLE
Terraform version

### DIFF
--- a/deployments/aws/lb-connectors-ha-lls/versions.tf
+++ b/deployments/aws/lb-connectors-ha-lls/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/deployments/aws/lb-connectors-lls/versions.tf
+++ b/deployments/aws/lb-connectors-lls/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/deployments/aws/lb-connectors/versions.tf
+++ b/deployments/aws/lb-connectors/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/deployments/aws/single-connector/versions.tf
+++ b/deployments/aws/single-connector/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/deployments/gcp/dc-only/versions.tf
+++ b/deployments/gcp/dc-only/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/deployments/gcp/multi-region/versions.tf
+++ b/deployments/gcp/multi-region/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/deployments/gcp/nlb-multi-region/versions.tf
+++ b/deployments/gcp/nlb-multi-region/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/deployments/gcp/single-connector/versions.tf
+++ b/deployments/gcp/single-connector/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google-beta = {
       source  = "hashicorp/google-beta"

--- a/modules/aws/cac/versions.tf
+++ b/modules/aws/cac/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/centos-gfx/versions.tf
+++ b/modules/aws/centos-gfx/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/centos-std/versions.tf
+++ b/modules/aws/centos-std/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/dc/versions.tf
+++ b/modules/aws/dc/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/ha-lls/versions.tf
+++ b/modules/aws/ha-lls/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/lls/versions.tf
+++ b/modules/aws/lls/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/win-gfx/versions.tf
+++ b/modules/aws/win-gfx/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/aws/win-std/versions.tf
+++ b/modules/aws/win-std/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     aws = {
       source = "hashicorp/aws"

--- a/modules/gcp/cac-igm/versions.tf
+++ b/modules/gcp/cac-igm/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/cac-regional/versions.tf
+++ b/modules/gcp/cac-regional/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/cac/versions.tf
+++ b/modules/gcp/cac/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/centos-gfx/versions.tf
+++ b/modules/gcp/centos-gfx/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/centos-std/versions.tf
+++ b/modules/gcp/centos-std/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/dc/versions.tf
+++ b/modules/gcp/dc/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/win-gfx/versions.tf
+++ b/modules/gcp/win-gfx/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/modules/gcp/win-std/versions.tf
+++ b/modules/gcp/win-std/versions.tf
@@ -6,7 +6,7 @@
  */
 
 terraform {
-  required_version = ">= 0.13"
+  required_version = ">= 0.14"
   required_providers {
     google = {
       source = "hashicorp/google"

--- a/quickstart/install-terraform.py
+++ b/quickstart/install-terraform.py
@@ -13,7 +13,7 @@ import zipfile
 
 
 TEMP_DIR           = '/tmp'
-TERRAFORM_VERSION  = '0.13.5'
+TERRAFORM_VERSION  = '0.14.0'
 
 
 def terraform_install(terraform_bin_dir, version):


### PR DESCRIPTION
Updated terraform version from 0.13 to 0.14 for both AWS and GCP.