### PR TITLE
Altered local sleeping during domain controller reboot to use time_sleep

### DIFF
--- a/modules/aws/dc/main.tf
+++ b/modules/aws/dc/main.tf
@@ -248,24 +248,20 @@ resource "null_resource" "run-provisioning-script" {
   }
 }
 
-resource "null_resource" "wait-for-reboot" {
+resource "time_sleep" "wait-for-reboot" {
   depends_on = [null_resource.run-provisioning-script]
   triggers = {
     id = aws_instance.dc.id
   }
 
-  provisioner "local-exec" {
-    # This command is written in such a way that it would work if the 
-    # local-exec is either the Command Prompt in Windows or the bash shell 
-    # in Linux. Note that it does not work on PowerShell in Windows.
-    command = "sleep 15 || timeout /nobreak /t 15"
-  }
+  create_duration = "15s"
+
 }
 
 resource "null_resource" "new-domain-admin-user" {
   depends_on = [
     null_resource.upload-scripts,
-    null_resource.wait-for-reboot,
+    time_sleep.wait-for-reboot,
   ]
   triggers = {
     id = aws_instance.dc.id

--- a/modules/gcp/dc/main.tf
+++ b/modules/gcp/dc/main.tf
@@ -182,24 +182,20 @@ resource "null_resource" "run-provisioning-script" {
   }
 }
 
-resource "null_resource" "wait-for-reboot" {
+resource "time_sleep" "wait-for-reboot" {
   depends_on = [null_resource.run-provisioning-script]
   triggers = {
-    instance_id = google_compute_instance.dc.instance_id
+    id = google_compute_instance.dc.instance_id
   }
 
-  provisioner "local-exec" {
-    # This command is written in such a way that it would work if the 
-    # local-exec is either the Command Prompt in Windows or the bash shell 
-    # in Linux. Note that it does not work on PowerShell in Windows.
-    command = "sleep 15 || timeout /nobreak /t 15"
-  }
+  create_duration = "15s"
+
 }
 
 resource "null_resource" "new-domain-admin-user" {
   depends_on = [
     null_resource.upload-scripts,
-    null_resource.wait-for-reboot,
+    time_sleep.wait-for-reboot,
   ]
   triggers = {
     instance_id = google_compute_instance.dc.instance_id


### PR DESCRIPTION
Windows CMD issues of unsupported Input Redirection were circumvented via this change. This should broaden the scope of applicable OS/shell implementation by using a dedicated resource.