### PR TITLE
Gcp os update

### DIFF
--- a/deployments/gcp/cam-multi-region/vars.tf
+++ b/deployments/gcp/cam-multi-region/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -291,7 +291,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count_list" {
@@ -316,7 +316,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/cam-multi-region/vars.tf
+++ b/deployments/gcp/cam-multi-region/vars.tf
@@ -180,7 +180,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cam-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cam-nlb-multi-region/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -291,7 +291,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count_list" {
@@ -316,7 +316,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/cam-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cam-nlb-multi-region/vars.tf
@@ -180,7 +180,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cam-single-connector/vars.tf
+++ b/deployments/gcp/cam-single-connector/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -266,7 +266,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count" {
@@ -291,7 +291,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count" {

--- a/deployments/gcp/cam-single-connector/vars.tf
+++ b/deployments/gcp/cam-single-connector/vars.tf
@@ -149,7 +149,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -64,7 +64,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -256,7 +256,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count_list" {
@@ -281,7 +281,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -135,7 +135,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -256,7 +256,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count_list" {
@@ -281,7 +281,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count_list" {

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -135,7 +135,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "dc_admin_password" {
@@ -231,7 +231,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "win_std_instance_count" {
@@ -256,7 +256,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
 }
 
 variable "centos_gfx_instance_count" {

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -104,7 +104,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210108"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210112"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?


### PR DESCRIPTION
Updated both windowos and ubuntuos.
Windows os: From 'windows-server-2019-dc-v20201208' to 'windows-server-2019-dc-v20210112'
Ubuntu os: From 'ubuntu-1804-bionic-v20210108' to 'ubuntu-1804-bionic-v20210112'