### PR TITLE
GCP: Updated Ubuntu OS in vars.tf files

### DIFF
--- a/deployments/gcp/cam-multi-region/vars.tf
+++ b/deployments/gcp/cam-multi-region/vars.tf
@@ -180,7 +180,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cam-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cam-nlb-multi-region/vars.tf
@@ -180,7 +180,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cam-single-connector/vars.tf
+++ b/deployments/gcp/cam-single-connector/vars.tf
@@ -149,7 +149,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -135,7 +135,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -135,7 +135,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -104,7 +104,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210119a"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210129"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?


### PR DESCRIPTION
We have updated the latest ubuntu OS version from "ubuntu-1804-bionic-v20210119a" to "ubuntu-1804-bionic-v20210129".