### PR TITLE
Gcp os update

### DIFF
--- a/deployments/gcp/cas-mgr-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-multi-region/terraform.tfvars.sample
@@ -88,11 +88,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # centos_gfx_machine_type      = "n1-standard-2"
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/cas-mgr-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-multi-region/terraform.tfvars.sample
@@ -98,11 +98,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/cas-mgr-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-multi-region/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -331,7 +331,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -361,7 +361,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/cas-mgr-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-multi-region/vars.tf
@@ -401,7 +401,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count_list" {
@@ -426,7 +426,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/cas-mgr-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-multi-region/vars.tf
@@ -200,7 +200,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cas-mgr-nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-nlb-multi-region/terraform.tfvars.sample
@@ -85,11 +85,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # centos_gfx_machine_type      = "n1-standard-2"
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/cas-mgr-nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-nlb-multi-region/terraform.tfvars.sample
@@ -95,11 +95,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -331,7 +331,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -361,7 +361,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
@@ -401,7 +401,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count_list" {
@@ -426,7 +426,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
+++ b/deployments/gcp/cas-mgr-nlb-multi-region/vars.tf
@@ -200,7 +200,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/cas-mgr-single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-single-connector/terraform.tfvars.sample
@@ -70,12 +70,12 @@ centos_gfx_instance_count      = 0
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/cas-mgr-single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/cas-mgr-single-connector/terraform.tfvars.sample
@@ -58,12 +58,12 @@ win_gfx_instance_count      = 0
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 centos_gfx_instance_count      = 0
 # centos_gfx_machine_type      = "n1-standard-2"

--- a/deployments/gcp/cas-mgr-single-connector/vars.tf
+++ b/deployments/gcp/cas-mgr-single-connector/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -306,7 +306,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -336,7 +336,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/cas-mgr-single-connector/vars.tf
+++ b/deployments/gcp/cas-mgr-single-connector/vars.tf
@@ -376,7 +376,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count" {
@@ -401,7 +401,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/cas-mgr-single-connector/vars.tf
+++ b/deployments/gcp/cas-mgr-single-connector/vars.tf
@@ -164,7 +164,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/dc-only/vars.tf
+++ b/deployments/gcp/dc-only/vars.tf
@@ -69,7 +69,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -79,11 +79,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # centos_gfx_machine_type      = "n1-standard-2"
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/multi-region/terraform.tfvars.sample
@@ -89,11 +89,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -145,7 +145,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -361,7 +361,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count_list" {
@@ -386,7 +386,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/multi-region/vars.tf
+++ b/deployments/gcp/multi-region/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -291,7 +291,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -321,7 +321,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -76,11 +76,11 @@ centos_std_instance_count_list = []
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 # centos_gfx_machine_type      = "n1-standard-2"
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"

--- a/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
+++ b/deployments/gcp/nlb-multi-region/terraform.tfvars.sample
@@ -86,11 +86,11 @@ centos_std_instance_count_list = []
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -145,7 +145,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -361,7 +361,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count_list" {
@@ -386,7 +386,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {

--- a/deployments/gcp/nlb-multi-region/vars.tf
+++ b/deployments/gcp/nlb-multi-region/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -291,7 +291,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -321,7 +321,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -49,12 +49,12 @@ win_gfx_instance_count      = 0
 # win_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # win_gfx_accelerator_count = 1
 # win_gfx_disk_size_gb      = 50
-# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_gfx_disk_image        = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 win_std_instance_count = 0
 # win_std_machine_type = "n1-standard-4"
 # win_std_disk_size_gb = 50
-# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20201208"
+# win_std_disk_image   = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 
 centos_gfx_instance_count      = 0
 # centos_gfx_machine_type      = "n1-standard-2"

--- a/deployments/gcp/single-connector/terraform.tfvars.sample
+++ b/deployments/gcp/single-connector/terraform.tfvars.sample
@@ -61,12 +61,12 @@ centos_gfx_instance_count      = 0
 # centos_gfx_accelerator_type  = "nvidia-tesla-p4-vws"
 # centos_gfx_accelerator_count = 1
 # centos_gfx_disk_size_gb      = 50
-# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_gfx_disk_image        = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_std_instance_count = 0
 # centos_std_machine_type = "n1-standard-2"
 # centos_std_disk_size_gb = 50
-# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210122"
+# centos_std_disk_image   = "projects/centos-cloud/global/images/centos-7-v20210217"
 
 centos_admin_ssh_pub_key_file = "~/.ssh/id_rsa.pub"
 

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -109,7 +109,7 @@ variable "cac_disk_size_gb" {
 
 variable "cac_disk_image" {
   description = "Disk image for the Cloud Access Connector"
-  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210211"
+  default     = "projects/ubuntu-os-cloud/global/images/ubuntu-1804-bionic-v20210224"
 }
 
 # TODO: does this have to match the tag at the end of the SSH pub key?

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -74,7 +74,7 @@ variable "dc_disk_size_gb" {
 
 variable "dc_disk_image" {
   description = "Disk image for the Domain Controller"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "dc_admin_password" {
@@ -266,7 +266,7 @@ variable "win_gfx_disk_size_gb" {
 
 variable "win_gfx_disk_image" {
   description = "Disk image for the Windows Graphics Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_gfx_pcoip_agent_version" {
@@ -296,7 +296,7 @@ variable "win_std_disk_size_gb" {
 
 variable "win_std_disk_image" {
   description = "Disk image for the Windows Standard Workstation"
-  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210112"
+  default     = "projects/windows-cloud/global/images/windows-server-2019-dc-v20210212"
 }
 
 variable "win_std_pcoip_agent_version" {

--- a/deployments/gcp/single-connector/vars.tf
+++ b/deployments/gcp/single-connector/vars.tf
@@ -336,7 +336,7 @@ variable "centos_gfx_disk_size_gb" {
 
 variable "centos_gfx_disk_image" {
   description = "Disk image for the CentOS Graphics Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_std_instance_count" {
@@ -361,7 +361,7 @@ variable "centos_std_disk_size_gb" {
 
 variable "centos_std_disk_image" {
   description = "Disk image for the CentOS Standard Workstation"
-  default     = "projects/centos-cloud/global/images/centos-7-v20210122"
+  default     = "projects/centos-cloud/global/images/centos-7-v20210217"
 }
 
 variable "centos_admin_user" {


### PR DESCRIPTION
Windows os changed from "windows-server-2019-dc-v20210112" to "windows-server-2019-dc-v20210212".
Centos changed from "centos-7-v20210122" to "centos-7-v20210217".
Ubuntu os changed from "ubuntu-1804-bionic-v20210211" to "ubuntu-1804-bionic-v20210224".